### PR TITLE
Convert Names to CMS

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Chodera lab // Memorial Sloan Kettering Cancer Center
+Copyright (c) 2018 Molecular Software Sciences Institute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Cookiecutter for Computational Chemistry Python Packages
+# Cookiecutter for Computational Molecular Science (CMS) Python Packages
 [//]: # (Badges)
-[![Travis Build Status](https://travis-ci.org/choderalab/cookiecutter-compchem.png)](https://travis-ci.org/choderalab/cookiecutter-compchem)
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/plygjybxqxy04rad/branch/master?svg=true)](https://ci.appveyor.com/project/lnaden/cookiecutter-compchem/branch/master)
-[![Documentation Status](https://readthedocs.org/projects/compchem-cookiecutter/badge/?version=latest)](http://compchem-cookiecutter.readthedocs.io/en/latest/?badge=latest)
+[![Travis Build Status](https://travis-ci.org/MolSSI/cookiecutter-cms.svg?branch=master)](https://travis-ci.org/MolSSI/cookiecutter-cms)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/yxb39cib8osqg41l/branch/master?svg=true)](https://ci.appveyor.com/project/Lnaden/cookiecutter-cms/branch/master)
+[![Documentation Status](https://readthedocs.org/projects/cookiecutter-cms/badge/?version=latest)](https://cookiecutter-cms.readthedocs.io/en/latest/?badge=latest)
 
 
 A [cookiecutter](https://github.com/audreyr/cookiecutter) template for those interested in developing computational 
-chemistry packages in Python. Skeletal starting repositories can be created from this template to create the 
+molecular packages in Python. Skeletal starting repositories can be created from this template to create the 
 file structure semi-autonomously so you can focus on what's important: the science!
 
 The skeletal structure is designed to help you get started, but do not feel limited by the skeleton's features 
@@ -38,13 +38,13 @@ With [`cookiecutter` installed](https://cookiecutter.readthedocs.io/en/latest/in
 execute the following command inside the folder you want to create the skeletal repository. 
 
 ```bash
-cookiecutter gh:choderalab/cookiecutter-compchem
+cookiecutter gh:molssi/cookiecutter-cms
 ```
 
 Which fetches this repository from github automatically and prompts the user for some simple information such as 
 package name, author(s), and licences. 
 
-[![The cookiecutter in action](http://img.youtube.com/vi/_E7AlaG8zbk/0.jpg)](http://www.youtube.com/watch?v=_E7AlaG8zbk "Computational Chemistry Cookieucutter Example")
+[![The cookiecutter in action](http://img.youtube.com/vi/_E7AlaG8zbk/0.jpg)](http://www.youtube.com/watch?v=_E7AlaG8zbk "Computational Molecular Sciences Cookieucutter Example")
 
 ## Next steps and web integrations
 The repository contains a number of "hooks" that integrate with a variety of web services. To fully integrate the project
@@ -67,7 +67,7 @@ proceed from there.
 The Python testing framework was chosen to be [pytest](https://pytest.org) for this project. Other testing frameworks are available;
 however, the authors believe the combination of easy [parametrization of tests](https://docs.pytest.org/en/latest/parametrize.html),
 [fixtures](https://docs.pytest.org/en/latest/fixture.html), and [test marking](https://docs.pytest.org/en/latest/example/markers.html)
-make `pytest` particularly suited for computational chemistry.
+make `pytest` particularly well suited for molecular software packages.
 
 To get started additional tests can be added to the `project/tests/` folder. Any function starting with `test_*` will automatically be
 included in the testing framework. While these can be added in anywhere in your directory structure, it is highly recommended to keep them
@@ -246,11 +246,13 @@ upon setup.
 
 ## Acknowledgments
 
-This cookiecutter is developed by Levi N. Naden of Memorial Sloan Kettering Cancer Center in conjunction with 
+This cookiecutter is developed by Levi N. Naden and 
 Daniel G. A. Smith from the [Molecular Sciences Software Institute (MolSSI)](http://molssi.org/). Copyright (c) 2018.
 
 Directory structure template based on recommendation from the 
 [Chodera Lab's Software Development Guidelines](https://github.com/choderalab/software-development/blob/master/STRUCTURING_YOUR_PROJECT.md).
+
+Original hosting of repository owned by the [Chodera Lab](https://github.com/choderalab)
 
 Elements of this repository drawn from the 
 [cookiecutter-data-science](https://github.com/drivendata/cookiecutter-data-science) by Driven Data

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cookiecutter for Computational Molecular Science (CMS) Python Packages
+# Cookiecutter for Computational Molecular Sciences (CMS) Python Packages
 [//]: # (Badges)
 [![Travis Build Status](https://travis-ci.org/MolSSI/cookiecutter-cms.svg?branch=master)](https://travis-ci.org/MolSSI/cookiecutter-cms)
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/yxb39cib8osqg41l/branch/master?svg=true)](https://ci.appveyor.com/project/Lnaden/cookiecutter-cms/branch/master)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = ComputationalChemistryCookiecutter
+SPHINXPROJ    = ComputationalMolecularScienceCookiecutter
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -4,7 +4,7 @@
 # You can set these variables from the command line.
 SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
-SPHINXPROJ    = ComputationalMolecularScienceCookiecutter
+SPHINXPROJ    = ComputationalMolecularSciencesCookiecutter
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'Computational Chemistry Cookiecutter'
+project = 'Computational Molecular Sciences Cookiecutter'
 copyright = '2018, Levi N. Naden, Daniel G. A. Smith'
 author = 'Levi N. Naden, Daniel G. A. Smith'
 
@@ -102,7 +102,7 @@ html_static_path = ['_static']
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ComputationalChemistryCookiecutterdoc'
+htmlhelp_basename = 'ComputationalMolecularScienceCookiecutterdoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -129,7 +129,9 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ComputationalChemistryCookiecutter.tex', 'Computational Chemistry Cookiecutter Documentation',
+    (master_doc,
+     'ComputationalMolecularScienceCookiecutter.tex',
+     'Computational Molecular Sciences Cookiecutter Documentation',
      'Levi N. Naden, Daniel G. A. Smith', 'manual'),
 ]
 
@@ -139,7 +141,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'computationalchemistrycookiecutter', 'Computational Chemistry Cookiecutter Documentation',
+    (master_doc, 'computationalmolecularsciencecookiecutter',
+     'Computational Molecular Sciences Cookiecutter Documentation',
      [author], 1)
 ]
 
@@ -150,8 +153,10 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ComputationalChemistryCookiecutter', 'Computational Chemistry Cookiecutter Documentation',
-     author, 'ComputationalChemistryCookiecutter', 'One line description of project.',
+    (master_doc, 'ComputationalMolecularScienceCookiecutter',
+     'Computational Molecular Sciences Cookiecutter Documentation',
+     author, 'ComputationalMolecularScienceCookiecutter',
+     'A Cookiecutter which provides skeletal packages of Computational Molecular Science Software.',
      'Miscellaneous'),
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,7 +102,7 @@ html_static_path = ['_static']
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ComputationalMolecularScienceCookiecutterdoc'
+htmlhelp_basename = 'ComputationalMolecularSciencesCookiecutterdoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -130,7 +130,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc,
-     'ComputationalMolecularScienceCookiecutter.tex',
+     'ComputationalMolecularSciencesCookiecutter.tex',
      'Computational Molecular Sciences Cookiecutter Documentation',
      'Levi N. Naden, Daniel G. A. Smith', 'manual'),
 ]
@@ -141,7 +141,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'computationalmolecularsciencecookiecutter',
+    (master_doc, 'computationalmolecularsciencescookiecutter',
      'Computational Molecular Sciences Cookiecutter Documentation',
      [author], 1)
 ]
@@ -153,10 +153,10 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ComputationalMolecularScienceCookiecutter',
+    (master_doc, 'ComputationalMolecularSciencesCookiecutter',
      'Computational Molecular Sciences Cookiecutter Documentation',
-     author, 'ComputationalMolecularScienceCookiecutter',
-     'A Cookiecutter which provides skeletal packages of Computational Molecular Science Software.',
+     author, 'ComputationalMolecularSciencesCookiecutter',
+     'A Cookiecutter which provides skeletal packages of Computational Molecular Sciences Software.',
      'Miscellaneous'),
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Cookiecutter for Computational Molecular Sciences Python Packages
 
 
 A `cookiecutter <https://github.com/audreyr/cookiecutter>`_ template for those interested in developing computational
-molecular science packages in Python. Skeletal starting repositories can be created from this template to create the
+molecular sciences packages in Python. Skeletal starting repositories can be created from this template to create the
 file structure semi-autonomously so you can focus on what's important: the science!
 
 The skeletal structure is designed to help you get started, but do not feel limited by the skeleton's features

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
-.. Computational Chemistry Cookiecutter documentation master file, created by
+.. Computational Molecular Sciences Cookiecutter documentation master file, created by
    sphinx-quickstart on Fri Apr 27 10:12:46 2018.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Cookiecutter for Computational Chemistry Python Packages
-========================================================
+Cookiecutter for Computational Molecular Sciences Python Packages
+=================================================================
 
 .. note::
 
@@ -13,7 +13,7 @@ Cookiecutter for Computational Chemistry Python Packages
 
 
 A `cookiecutter <https://github.com/audreyr/cookiecutter>`_ template for those interested in developing computational
-chemistry packages in Python. Skeletal starting repositories can be created from this template to create the
+molecular science packages in Python. Skeletal starting repositories can be created from this template to create the
 file structure semi-autonomously so you can focus on what's important: the science!
 
 The skeletal structure is designed to help you get started, but do not feel limited by the skeleton's features
@@ -51,7 +51,7 @@ execute the following command inside the folder you want to create the skeletal 
 
 .. code:: bash
 
-   cookiecutter gh:choderalab/cookiecutter-compchem
+   cookiecutter gh:molssi/cookiecutter-cms
 
 
 Which fetches this repository from github automatically and prompts the user for some simple information such as
@@ -90,13 +90,13 @@ Testing
 The Python testing framework was chosen to be `pytest <https://pytest.org>`_ for this project. Other testing frameworks are available;
 however, the authors believe the combination of easy `parametrization of tests <https://docs.pytest.org/en/latest/parametrize.html>`_,
 `fixtures <https://docs.pytest.org/en/latest/fixture.html>`_, and `test marking <https://docs.pytest.org/en/latest/example/markers.html>`_
-make ``pytest`` particularly suited for computational chemistry.
+make ``pytest`` particularly well suited for molecular software packages.
 
 To get started additional tests can be added to the ``project/tests/`` folder. Any function starting with ``test_*`` will automatically be
 included in the testing framework. While these can be added in anywhere in your directory structure, it is highly recommended to keep them
 contained within the ``project/tests/`` folder.
 
-Tests can be run with the ``py.test -v`` command. There are a number of additional command line arguments to 
+Tests can be run with the ``pytest -v`` command. There are a number of additional command line arguments to
 `explore <https://docs.pytest.org/en/latest/usage.html>`_.
 
 Continuous Integration
@@ -197,11 +197,13 @@ Additional Pages
 Acknowledgments
 ===============
 
-This cookiecutter is developed by Levi N. Naden of Memorial Sloan Kettering Cancer Center in conjunction with
+This cookiecutter is developed by Levi N. Naden and
 Daniel G. A. Smith from the `Molecular Sciences Software Institute (MolSSI) <http://molssi.org/>`_. Copyright (c) 2018.
 
 Directory structure template based on recommendation from the
 `Chodera Lab's Software Development Guidelines <https://github.com/choderalab/software-development/blob/master/STRUCTURING_YOUR_PROJECT.md>`_.
+
+Original hosting of repository owned by the `Chodera Lab <https://github.com/choderalab>`_
 
 Elements of this repository drawn from the
 `cookiecutter-data-science <https://github.com/drivendata/cookiecutter-data-science>`_ by Driven Data

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,7 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
-set SPHINXPROJ=ComputationalMolecularScienceCookiecutter
+set SPHINXPROJ=ComputationalMolecularSciencesCookiecutter
 
 if "%1" == "" goto help
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,7 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
-set SPHINXPROJ=ComputationalChemistryCookiecutter
+set SPHINXPROJ=ComputationalMolecularScienceCookiecutter
 
 if "%1" == "" goto help
 

--- a/docs/nuances.rst
+++ b/docs/nuances.rst
@@ -1,7 +1,7 @@
 Warnings and Caveats from the Cookiecutter
 ==========================================
 
-We encourage users to look at the parent Computational Chemistry Cookiecutter as ways to template their own output
+We encourage users to look at the parent Computational Molecular Sciences Cookiecutter as ways to template their own output
 projects from the `Cookiecutter <https://github.com/audreyr/cookiecutter>`_. However, there are a few things the
 parent does to make the illustration work, but should probably not be followed in your projects. These are mostly
 because the parent has to simulate an output, then test the output of the cookiecutter, which is something you will

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -36,7 +36,7 @@ def git_init_and_tag():
     invoke_shell("git init")
     # Add files
     invoke_shell("git add .")
-    invoke_shell("git commit -m \"Initial commit after Comp. Chem. Cookiecutter creation\"")
+    invoke_shell("git commit -m \"Initial commit after CMS Cookiecutter creation\"")
     # Set the 0.0.0 tag
     invoke_shell("git tag 0.0.0")
 

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -17,4 +17,4 @@ Copyright (c) {% now 'utc', '%Y' %}, {{cookiecutter.author_name}}
 #### Acknowledgements
  
 Project based on the 
-[Computational Chemistry Python Cookiecutter](https://github.com/choderalab/cookiecutter-python-comp-chem)
+[Computational Molecular Science Python Cookiecutter](https://github.com/molssi/cookiecutter-cms)


### PR DESCRIPTION
This converts all the names I could find which referenced "Computational
Chemistry Cookiecutter" to "Computational Molecular Science Cookiecutter,"
including all the shorthand and substitution.

Re-licenses under MolSSI as owner instead of Chodera Lab

Fixed badges to point to new builds under MolSSI/cookiecutter-cms

Fixes #45