### PR TITLE
Stamp output skeleton with the Cookiecutter Template version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,13 @@
 environment:
 
   matrix:
-    - PYTHON: "C:\\Miniconda35-x64"
+    - PYTHON: "C:\\Miniconda36-x64"
       LICENSE: 1
       DEPEND_SOURCE: 1
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Miniconda36-x64"
+    - PYTHON: "C:\\Miniconda37-x64"
       LICENSE: 2
       DEPEND_SOURCE: 2
       PYTHON_VERSION: "3.7"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,5 +9,6 @@
         "Prefer conda-forge over the default anaconda channel with pip fallback",
         "Prefer default anaconda channel with pip fallback",
         "Dependencies from pip only (no conda)"],
-    "Include_Windows_continuous_integration": ["y","n"]
+    "Include_Windows_continuous_integration": ["y","n"],
+    "_cms_cc_version": 1.0
 }

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -17,4 +17,4 @@ Copyright (c) {% now 'utc', '%Y' %}, {{cookiecutter.author_name}}
 #### Acknowledgements
  
 Project based on the 
-[Computational Molecular Science Python Cookiecutter](https://github.com/molssi/cookiecutter-cms)
+[Computational Molecular Science Python Cookiecutter](https://github.com/molssi/cookiecutter-cms) version {{cookiecutter._cms_cc_version}}

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -20,7 +20,8 @@
 # -- Project information -----------------------------------------------------
 
 project = '{{cookiecutter.description}}'
-copyright = "{% now 'utc', '%Y' %}, {{cookiecutter.author_name}}"
+copyright = ("{% now 'utc', '%Y' %}, {{cookiecutter.author_name}}. Project structure based on the "
+             "Computational Molecular Science Python Cookiecutter version {{cookiecutter._cms_cc_version}}")
 author = '{{cookiecutter.author_name}}'
 
 # The short X.Y version


### PR DESCRIPTION
Adds provenance information to the output project based on the current
version of the CMS cookiecutter template itself (*not* the cookiecutter
program). Right now its a manual update of the version in the
`cookiecutter.json` file, but its better than touching it everywhere by
hand. The way its implemented is undocumented in Cookiecutter itself
and my intuition is its unsafe, but I cannot think of a simpler
solution (xref audreyr/cookiecutter#1135).

This may be the formal solution to #48, but for now, it should be
considered a partial fix.