### PR TITLE
Convert testing to Conda Env instead of Conda Build

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,72 @@ package managers, Huzzah!
 * [Conda's Package Management docs](https://conda.io/docs/user-guide/tasks/manage-pkgs.html)
 * [`pip` User Guide](https://pip.pypa.io/en/stable/user_guide/)
 
+## Conda Build vs. Conda Environments
 
+We recommend creating Conda environments rather than relying on conda build for *testing* purposes, assuming you have 
+opted for Conda as a dependency manager. Earlier versions of this Cookiecutter would conduct testing by first 
+bundling the package for distribution through 
+[Conda Build](https://conda.io/docs/user-guide/tasks/build-packages/index.html), and then installing the package 
+locally to execute tests on. This had the advantage of ensuring your package *could* be bundled for distribution and 
+that all of its dependencies resolved correctly. However, it had the disadvantage of being painfully slow and rather
+confusing to debug should things go wrong on the build, even before the testing. 
+
+The replacement option to this is to pre-create the conda environment and then install your package into it with 
+no dependency resolution for testing. This helps separate out the concepts of **testing** and **deployment** which 
+are separate actions, even though deployment should only come after testing, and you should be ready to do both. 
+This should simplify and accelerate  the testing process, but 
+does mean maintaining two, albeit similar, files since a Conda Environment file has a different YAML syntax than 
+a Conda Build  `meta.yaml` file. We feel this benefits outweigh the costs and have adopted this model.
+
+## Deploying your code
+
+Simply testing your code is insufficient for good coding practices, you *should* be ready to deploy 
+your code as well. Do not be afraid of deployment though; Python deployment over the last several years 
+has been getting easier, especially when there are others to manage your deployment for you. 
+There are several ways to handle this, we will cover a couple here, depending on the conditions 
+which best suit your needs. The list below is neither exhaustive nor exclusive. There are times
+when you may want to build your packages yourself and upload them for developmental purposes, 
+but we recommend letting others handle (and help you) with deployment.
+These are meant to serve as guides to help you get started.
+
+Deployment should not get in the way of testing. You could configure the Travis and AppVeyor scripts
+to handle the build stage after the test stage, but this is should only be done by advanced 
+users or those looking to deploy themselves.
+
+
+### Deployment Method 1: Conda Forge
+
+The [Conda Forge](https://conda-forge.org/) community is a great, and the recommended location to deploy your 
+packages. The community is highly active and many scientific developers have been moving here to access not 
+only Conda Forge's deployment tools, but also for easy access to all the other Python packages which have 
+been deployed on the platform. Even though they provide the deployment architecture, you need to still 
+test your program's ability to be packaged through `conda-build`. 
+If you choose either Conda dependency option, additional 
+tests will be added to Travis and/or AppVeyor which *only* package through `conda-build`.
+
+This method relies on the conda `meta.yaml` file.
+
+### Deployment Method 2: Conda through someone else's manager
+
+This option is identical to the Conda Forge method, but relies on a different group's deployment platform
+such as [Bioconda](https://bioconda.github.io/) or [Omnia](http://www.omnia.md/). Each platform has their
+own rules, which may include packaging your program yourself and uploading. Check each platform's 
+instructions and who else deploys to them before choosing this option to ensure its right for you.
+
+This method relies on the conda `meta.yaml` file.
+
+## Deployment Method 3: Upload package to PyPi
+
+The [Python Package Index (PyPi)](https://pypi.org/) is another place to manage your package and have 
+dependencies resolve. This option typically relies on `pip` to create your packages and dependencies 
+must be specified in your `setup.py` file to resolve correctly.
+
+### Deployment Method 4: Manually upload your package to some source 
+
+Sometimes, your package is niche enough, developmental enough, or proprietary enough to warrant manually 
+packaging and uploading your program. This may also apply if you want regular developmental builds which you 
+upload manually to test. In this case, you will want to change your CI scripts to include a build, and 
+optional upload step on completion of tests.
 
 ## Output Skeleton
 
@@ -225,10 +290,14 @@ upon setup.
 │   └── _version.py                 <- Automatic version control with Versioneer
 ├── devtools                        <- Deployment, packaging, and CI helpers directory 
 │   ├── README.md
+│   ├── conda-envs                  <- Environments for testing
+│   │   └── test_env.yaml
 │   ├── conda-recipe                <- Conda build and deployment skeleton
 │   │   ├── bld.bat                 <- Win specific file, not present if Win CI not chosen
 │   │   ├── build.sh
 │   │   └── meta.yaml
+│   ├── scripts
+│   │   └── create_conda_env.py     <- OS anostic Helper script to make conda environments based on simple flags
 │   └── travis-ci
 │       └── install.sh
 ├── docs                            <- Documentation template folder with many settings already filled in

--- a/cihelpers/osx_travis_py_helper.sh
+++ b/cihelpers/osx_travis_py_helper.sh
@@ -11,7 +11,9 @@
 # ...
 # SIGH - LNN
 
-# Use PyEnv, dont let brew update EVERYTHING ELSE that we don't need it to
+# IMPORTANT: This should ONLY be used for OSX in Travis CI, not for local production builds of any kind
+
+# Use PyEnv, don't let brew update EVERYTHING ELSE that we don't need it to
 HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade pyenv
 # Pyenv requires minor revision, get the latest
 PYENV_VERSION=$(pyenv install --list |grep $PYTHON_VER | sed -n "s/^[ \t]*\(${PYTHON_VER}\.*[0-9]*\).*/\1/p" | tail -n 1)

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 # Run jobs on container-based infrastructure, can be overridden per job
-dist: xenial
 
 matrix:
   include:
@@ -33,19 +32,15 @@ before_install:
 install:
 {% if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
     # Install the package locally
-  - pip install pytest pytest-cov codecov
+  - pip install -U pytest pytest-cov codecov
   - pip install -e .
 {% else %}
     # Create test environment for package
-  - conda create -n test python=$PYTHON_VER pip pytest pytest-cov
+  - python devtools/scripts/create_conda_env.py -n=test -p=$PYTHON_VER devtools/conda-envs/test_env.yaml
+    # Activate the test environment
   - conda activate test
-
-    # Install pip only modules
-  - pip install codecov
-
     # Build and install package
-  - conda build --python=$PYTHON_VER devtools/conda-recipe
-  - conda install --use-local {{cookiecutter.repo_name}}
+  - python setup.py develop --no-deps
 {% endif %}
 
 script:

--- a/{{cookiecutter.repo_name}}/appveyor.yml
+++ b/{{cookiecutter.repo_name}}/appveyor.yml
@@ -34,18 +34,16 @@ install:
 
     # Try to update conda first to avoid odd dependency clashes
   - conda update --all
-  - conda install conda-build
 
     # Create test environment for package
-  - conda create -n test python=%PYTHON_VERSION% pip pytest pytest-cov
+  - python devtools\\scripts\\create_conda_env.py -n=test -p=%PYTHON_VERSION% devtools\\conda-envs\\test_env.yaml
+
+    # Activate the test environment
   - activate test
-    
-    # Install any pip only modules
-  - pip install codecov
 
     # Build and install package
-  - conda build --quiet --python=%PYTHON_VERSION% devtools\\conda-recipe
-  - conda install --use-local {{cookiecutter.repo_name}}
+  - python setup.py develop --no-deps
+
   {% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
     # Install the package locally
   - pip install --upgrade pip setuptools
@@ -56,3 +54,6 @@ build: false
 
 test_script:
   - pytest -v --cov={{cookiecutter.repo_name}} {{cookiecutter.repo_name}}\\tests
+
+on_success:
+  - codecov

--- a/{{cookiecutter.repo_name}}/devtools/README.md
+++ b/{{cookiecutter.repo_name}}/devtools/README.md
@@ -12,24 +12,39 @@ You should test your code, but do not feel compelled to use these specific progr
 Windows testing if you only plan to deploy on specific platforms. These are just to help you get started
 
 * `travis-ci`: Linux and OSX based testing through [Travis-CI](https://about.travis-ci.com/) 
-  * `install.sh`: Pip/Miniconda installation script for Travis
-* `appveyor`: Windows based testing through [AppVeyor](https://www.appveyor.com/)
-  * `install_conda.ps1` Powershell installation script of Conda components
+  * `before_install.sh`: Pip/Miniconda pre-package installation script for Travis 
+* `appveyor`: Windows based testing through [AppVeyor](https://www.appveyor.com/) (there are no files directly related to this)
 
 ### Conda Recipe:
 
-This directory contains the files to build and deploy on [Conda](https://conda.io/).
+This directory contains the files to build and deploy on [Conda](https://conda.io/). Although the Cookiecutter 
+does not do anything with this directory at the moment, we leave this here to show an example of how 
+your conda-recipe folder should look, when you decide to start deployment.
 
 * `conda-recipe`: directory containing all the build objects required for Conda. All files in this folder must have their given names
   * `meta.yaml`: The yaml file needed by Conda to construct the build
   * `build.sh`: Unix-based instructions for how to install the software interpreted by Conda
   * `bld.bat`: Windows-based instructions for how to install the software interpreted by Conda
+  
+### Conda Environment:
+
+This directory contains the files to setup the Conda environment for testing purposes
+
+* `conda-envs`: directory containing the YAML file(s) which fully describe Conda Environments, their dependencies, and those dependency provenance's
+  * `test_env.yaml`: Simple test environment file with base dependencies. Channels are not specified here and therefore respect global Conda configuration
+  
+### Additional Scripts:
+
+This directory contains OS agnostic helper scripts which don't fall in any of the previous categories
+* `scripts`
+  * `create_conda_env.py`: Helper program for spinning up new conda environments based on a starter file with Python Version and Env. Name command-line options
 
 
 ## How to contribute changes
 - Clone the repository if you have write access to the main repo, fork the repository if you are a collaborator.
 - Make a new branch with `git checkout -b {your branch name}`
 - Make changes and test your code
+- Ensure that the test environment dependencies (`conda-envs`) line up with the build and deploy dependencies (`conda-recipe/meta.yaml`)
 - Push the branch to the repo (either the main or your fork) with `git push -u origin {your branch name}`
   * Note that `origin` is the default name assigned to the remote, yours may be different
 - Make a PR on GitHub with your changes

--- a/{{cookiecutter.repo_name}}/devtools/conda-envs/test_env.yaml
+++ b/{{cookiecutter.repo_name}}/devtools/conda-envs/test_env.yaml
@@ -1,0 +1,14 @@
+name: test
+channels:
+dependencies:
+    # Base depends
+  - python
+  - pip
+
+    # Testing
+  - pytest
+  - pytest-cov
+
+    # Pip-only installs
+  - pip:
+    - codecov

--- a/{{cookiecutter.repo_name}}/devtools/scripts/create_conda_env.py
+++ b/{{cookiecutter.repo_name}}/devtools/scripts/create_conda_env.py
@@ -1,0 +1,95 @@
+import argparse
+import os
+import re
+import glob
+import shutil
+import subprocess as sp
+from tempfile import TemporaryDirectory
+from contextlib import contextmanager
+# YAML imports
+try:
+    import yaml  # PyYAML
+    loader = yaml.load
+except ImportError:
+    try:
+        import ruamel_yaml as yaml  # Ruamel YAML
+    except ImportError:
+        try:
+            # Load Ruamel YAML from the base conda environment
+            from importlib import util as import_util
+            CONDA_BIN = os.path.dirname(os.environ['CONDA_EXE'])
+            ruamel_yaml_path = glob.glob(os.path.join(CONDA_BIN, '..',
+                                                      'lib', 'python*.*', 'site-packages',
+                                                      'ruamel_yaml', '__init__.py'))[0]
+            # Based on importlib example, but only needs to load_module since its the whole package, not just
+            # a module
+            spec = import_util.spec_from_file_location('ruamel_yaml', ruamel_yaml_path)
+            yaml = spec.loader.load_module()
+        except (KeyError, ImportError, IndexError):
+            raise ImportError("No YAML parser could be found in this or the conda environment. "
+                              "Could not find PyYAML or Ruamel YAML in the current environment, "
+                              "AND could not find Ruamel YAML in the base conda environment through CONDA_EXE path. " 
+                              "Environment not created!")
+    loader = yaml.YAML(typ="safe").load  # typ="safe" avoids odd typing on output
+
+
+@contextmanager
+def temp_cd():
+    """Temporary CD Helper"""
+    cwd = os.getcwd()
+    with TemporaryDirectory() as td:
+        try:
+            os.chdir(td)
+            yield
+        finally:
+            os.chdir(cwd)
+
+
+# Args
+parser = argparse.ArgumentParser(description='Creates a conda environment from file for a given Python version.')
+parser.add_argument('-n', '--name', type=str,
+                    help='The name of the created Python environment')
+parser.add_argument('-p', '--python', type=str,
+                    help='The version of the created Python environment')
+parser.add_argument('conda_file',
+                    help='The file for the created Python environment')
+
+args = parser.parse_args()
+
+# Open the base file
+with open(args.conda_file, "r") as handle:
+    yaml_script = loader(handle.read())
+
+python_replacement_string = "python {}*".format(args.python)
+
+try:
+    for dep_index, dep_value in enumerate(yaml_script['dependencies']):
+        if re.match('python([ ><=*]+[0-9.*]*)?$', dep_value):  # Match explicitly 'python' and its formats
+            yaml_script['dependencies'].pop(dep_index)
+            break  # Making the assumption there is only one Python entry, also avoids need to enumerate in reverse
+except (KeyError, TypeError):
+    # Case of no dependencies key, or dependencies: None
+    yaml_script['dependencies'] = []
+finally:
+    # Ensure the python version is added in. Even if the code does not need it, we assume the env does
+    yaml_script['dependencies'].insert(0, python_replacement_string)
+
+# Figure out conda path
+if "CONDA_EXE" in os.environ:
+    conda_path = os.environ["CONDA_EXE"]
+else:
+    conda_path = shutil.which("conda")
+if conda_path is None:
+    raise RuntimeError("Could not find a conda binary in CONDA_EXE variable or in executable search path")
+
+print("CONDA ENV NAME  {}".format(args.name))
+print("PYTHON VERSION  {}".format(args.python))
+print("CONDA FILE NAME {}".format(args.conda_file))
+print("CONDA PATH      {}".format(conda_path))
+
+# Write to a temp directory which will always be cleaned up
+with temp_cd():
+    temp_file_name = "temp_script.yaml"
+    with open(temp_file_name, 'w') as f:
+        f.write(yaml.dump(yaml_script))
+    sp.call("{} env create -n {} -f {}".format(conda_path, args.name, temp_file_name), shell=True)

--- a/{{cookiecutter.repo_name}}/devtools/travis-ci/before_install.sh
+++ b/{{cookiecutter.repo_name}}/devtools/travis-ci/before_install.sh
@@ -39,7 +39,7 @@ conda install conda conda-build jinja2 anaconda-client
 conda update --quiet --all
 {% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew upgrade pyenv
+    HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade pyenv
     # Pyenv requires minor revision, get the latest
     PYENV_VERSION=$(pyenv install --list |grep $PYTHON_VER | sed -n "s/^[ \t]*\(${PYTHON_VER}\.*[0-9]*\).*/\1/p" | tail -n 1)
     # Install version


### PR DESCRIPTION
This PR moves the testing environment from relying on Conda-build
and instead creates conda envs which should speed up and simplify tests.

The trade off is the maintenance of multiple files for dependencies
going forward, but I think the benefits outweigh the costs.

Borrows from the QCFractal script from @dgasmith to spin up the
environments. Will need a careful review to make sure it meets our needs.

Fixes #50
Supersedes and Closes #47