### PR TITLE
Add `dist: xenial` to linux Python 3.7 in travis.yml

### DIFF
--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -16,6 +16,7 @@ matrix:
       python: 3.6
       env: PYTHON_VER=3.6
     - os: linux
+      dist: xenial
       python: 3.7
       env: PYTHON_VER=3.7
 


### PR DESCRIPTION
addresses #62 