### PR TITLE
Fix so that CookieCutter does not fail with no windows CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,36 +10,56 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.7
+        - WINDOWS_CI=1
     - os: osx
       language: generic
       env:
         - LICENSE=1
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.7
+        - WINDOWS_CI=1
     - os: osx
       language: generic
       env:
         - LICENSE=2
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.7
+        - WINDOWS_CI=1
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.7
+        - WINDOWS_CI=2
     - os: osx
       language: generic
       env:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.6
+        - WINDOWS_CI=1
     - os: osx
       language: generic
       env:
         - LICENSE=1
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.6
+        - WINDOWS_CI=1
     - os: osx
       language: generic
       env:
         - LICENSE=2
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.6
+        - WINDOWS_CI=1
+    - os: osx
+      language: generic
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.6
+        - WINDOWS_CI=2
 
     # Pin Xenial for 3.7
     - os: linux
@@ -49,6 +69,7 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.7
+        - WINDOWS_CI=1
 
     - os: linux
       dist: xenial
@@ -57,6 +78,7 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.7
+        - WINDOWS_CI=1
 
     - os: linux
       dist: xenial
@@ -65,6 +87,16 @@ matrix:
         - LICENSE=2
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.7
+        - WINDOWS_CI=1
+
+    - os: linux
+      dist: xenial
+      python: 3.7
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.7
+        - WINDOWS_CI=2
 
     - os: linux
       python: 3.6
@@ -72,6 +104,7 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.6
+        - WINDOWS_CI=1
 
     - os: linux
       python: 3.6
@@ -79,6 +112,7 @@ matrix:
         - LICENSE=1
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.6
+        - WINDOWS_CI=1
 
     - os: linux
       python: 3.6
@@ -86,6 +120,15 @@ matrix:
         - LICENSE=2
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.6
+        - WINDOWS_CI=1
+
+    - os: linux
+      python: 3.6
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.6
+        - WINDOWS_CI=2
 
 before_install:
     # Make sure pip is around, on OSX Travis we have to do some shenanigans
@@ -95,7 +138,7 @@ before_install:
   - pip install pyyaml cookiecutter
 
     # Build out the cookiecutter from settings
-  - python tests/setup_cookiecutter.py default_project $LICENSE $DEPEND_SOURCE
+  - python tests/setup_cookiecutter.py default_project $LICENSE $DEPEND_SOURCE $WINDOWS_CI
 
     # Change into new project directory
   - cd default_project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,18 +6,21 @@ environment:
       DEPEND_SOURCE: 1
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
+      WINDOWS: 1
 
     - PYTHON: "C:\\Miniconda37-x64"
       LICENSE: 2
       DEPEND_SOURCE: 2
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
+      WINDOWS: 1
 
     - PYTHON: "C:\\Python36-x64"
       LICENSE: 1
       DEPEND_SOURCE: 3
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
+      WINDOWS: 1
 
 
 
@@ -31,7 +34,7 @@ install:
   - git config --global core.autocrlf true
 
     # Build out the cookiecutter from settings
-  - python tests/setup_cookiecutter.py default_project %LICENSE% %DEPEND_SOURCE%
+  - python tests/setup_cookiecutter.py default_project %LICENSE% %DEPEND_SOURCE% %WINDOWS%
 
     # Change into new project directory
   - ps: cd default_project

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -46,7 +46,6 @@ def remove_windows_ci():
     if include_windows == "n":
         # Remove with appveyor to be a safe delete
         os.remove("appveyor.yml")
-        os.remove(os.path.join("devtools", "conda-recipe", "bld.bat"))
 
 
 remove_windows_ci()

--- a/tests/setup_cookiecutter.py
+++ b/tests/setup_cookiecutter.py
@@ -8,7 +8,8 @@ import sys
 project = sys.argv[1]
 lic = sys.argv[2]
 depend = sys.argv[3]
-print("Options: open_source_license=%s, dependency_source=%s" % (lic, depend)) 
+windows = sys.argv[4]
+print("Options: open_source_license=%s, dependency_source=%s, windows_ci=%s" % (lic, depend, windows))
 
 # Setup the options
 options = [project, # Repo name
@@ -19,7 +20,7 @@ options = [project, # Repo name
            "", # Description
            lic, # License
            depend, # Dependency
-           "1"] # Windows
+           windows] # Windows
 
 # Open a thread
 p = Popen(["cookiecutter", "."], stdin=PIPE, stdout=PIPE)


### PR DESCRIPTION
This PR addresses issue #75.

The issue itself was fixed by removing a reference to a conda build for windows continuous integration. 

I've also added tests for no Windows CI to travis (maintainers can decide if they'd like to include these).