### PR TITLE
Find packages, using Manifest.in, and a small fix in setup.py

### DIFF
--- a/{{cookiecutter.repo_name}}/MANIFEST.in
+++ b/{{cookiecutter.repo_name}}/MANIFEST.in
@@ -1,2 +1,6 @@
+include LICENSE
+include MANIFEST.in
+include versioneer.py
+
 graft {{cookiecutter.repo_name}}
 global-exclude *.py[cod] __pycache__ *.so

--- a/{{cookiecutter.repo_name}}/MANIFEST.in
+++ b/{{cookiecutter.repo_name}}/MANIFEST.in
@@ -1,0 +1,2 @@
+graft {{cookiecutter.repo_name}}
+global-exclude *.py[cod] __pycache__ *.so

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -37,10 +37,9 @@ setup(
     packages=find_packages(),
 
     # Optional include package data to ship with your package
+    # Customize MANIFEST.in if the general case does not suit your needs
     # Comment out this line to prevent the files from being packaged with your software
-    # Extend/modify the list to include/exclude other items as need be
-    package_data={'{{cookiecutter.repo_name}}': ["data/*.dat"]
-                  },
+    include_package_data=True,
 
     # Allows `setup.py test` to work correctly with pytest
     setup_requires=[] + pytest_runner,

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -3,7 +3,7 @@
 {{cookiecutter.description}}
 """
 import sys
-from setuptools import setup
+from setuptools import setup, find_packages
 import versioneer
 
 short_description = __doc__.split("\n")
@@ -32,7 +32,9 @@ setup(
     license='{{cookiecutter.open_source_license}}',
 
     # Which Python importable modules should be included when your package is installed
-    packages=['{{cookiecutter.repo_name}}', "{{cookiecutter.repo_name}}.tests"],
+    # Handled automatically by setuptools. Use 'exclude' to prevent some specific
+    # subpackage(s) from being added, if needed
+    packages=find_packages(),
 
     # Optional include package data to ship with your package
     # Comment out this line to prevent the files from being packaged with your software

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -45,7 +45,6 @@ setup(
     setup_requires=[] + pytest_runner,
 
     # Additional entries you may want simply uncomment the lines you want and fill in the data
-    # author_email='me@place.org',      # Author email
     # url='http://www.my_package.com',  # Website
     # install_requires=[],              # Required packages, pulls from pip if needed; do not use for Conda deployment
     # platforms=['Linux',


### PR DESCRIPTION
As discussed in issue #78, this PR adds:

- package autodiscovery 
- data management through MANIFEST.in

Also, while looking at setup.py, I found that `author_email` was mentioned again in the bottom comments, but it had been already defined some lines above.