### PR TITLE
remove comma from try/except that was causing error if no README

### DIFF
--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -16,7 +16,7 @@ try:
     with open("README.md", "r") as handle:
         long_description = handle.read()
 except:
-    long_description = "\n".join(short_description[2:]),
+    long_description = "\n".join(short_description[2:])
 
 
 setup(


### PR DESCRIPTION
There was a comma at the end of one line which was causing an error with install if there was no README. 

Addresses #87 