### PR TITLE
Docs: Basic docs information with napolean and autosummary

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/api.rst
+++ b/{{cookiecutter.repo_name}}/docs/api.rst
@@ -1,0 +1,7 @@
+API Documentation
+=================
+
+.. autosummary::
+   :toctree: autosummary
+
+   projectname.canvas

--- a/{{cookiecutter.repo_name}}/docs/api.rst
+++ b/{{cookiecutter.repo_name}}/docs/api.rst
@@ -4,4 +4,4 @@ API Documentation
 .. autosummary::
    :toctree: autosummary
 
-   projectname.canvas
+   {{cookiecutter.repo_name}}.canvas

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -17,7 +17,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 
-import projectname
+import {{cookiecutter.repo_name}}
 
 
 # -- Project information -----------------------------------------------------

--- a/{{cookiecutter.repo_name}}/docs/conf.py
+++ b/{{cookiecutter.repo_name}}/docs/conf.py
@@ -11,10 +11,13 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+
+# Incase the project was not installed
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+import projectname
 
 
 # -- Project information -----------------------------------------------------
@@ -40,9 +43,19 @@ release = ''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.autosummary',
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.extlinks',
 ]
+
+autosummary_generate = True
+napoleon_google_docstring = False
+napoleon_use_param = False
+napoleon_use_ivar = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -69,7 +82,7 @@ language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'default'
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/{{cookiecutter.repo_name}}/docs/getting_started.rst
+++ b/{{cookiecutter.repo_name}}/docs/getting_started.rst
@@ -1,0 +1,4 @@
+Getting Started
+===============
+
+This page details how to get started with {{cookiecutter.project_name}}. 

--- a/{{cookiecutter.repo_name}}/docs/index.rst
+++ b/{{cookiecutter.repo_name}}/docs/index.rst
@@ -10,6 +10,9 @@ Welcome to {{cookiecutter.project_name}}'s documentation!
    :maxdepth: 2
    :caption: Contents:
 
+   getting_started
+   api
+
 
 
 Indices and tables


### PR DESCRIPTION
Expands the doc sections to include function auto summary and a second example page.

Closes #68 by enabling Napolean through default libs.