### PR TITLE
Make Travis CI links/badge point to .com domain rather than .org

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Tests can be run with the `pytest -v` command. There are a number of additional 
 
 ### Continuous Integration
 Testing is accomplished with both [Appveyor](https://www.appveyor.com) (for Windows testing) and 
-[Travis-CI](https://travis-ci.org) (for Linux testing). These frameworks are chosen as they
+[Travis-CI](https://travis-ci.com) (for Linux testing). These frameworks are chosen as they
 are completely free for open source projects and allow you to automatically verify that your project works under a 
 variety of OS's and
 Python versions. To begin please register with both Appveyor and Travis-CI and turn on the git hooks under the project 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,7 +102,7 @@ Tests can be run with the ``pytest -v`` command. There are a number of additiona
 Continuous Integration
 ^^^^^^^^^^^^^^^^^^^^^^
 Testing is accomplished with both `Appveyor <https://www.appveyor.com>`_ (for Windows testing) and
-`Travis-CI <https://travis-ci.org>`_ (for Linux testing). These frameworks are chosen as they
+`Travis-CI <https://travis-ci.com>`_ (for Linux testing). These frameworks are chosen as they
 are completely free for open source projects and allow you to automatically verify that your project works under a
 variety of OS's and
 Python versions. To begin please register with both Appveyor and Travis-CI and turn on the git hooks under the project

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -1,7 +1,7 @@
 {{cookiecutter.project_name}}
 ==============================
 [//]: # (Badges)
-[![Travis Build Status](https://travis-ci.org/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}}.svg?branch=master)](https://travis-ci.org/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}})
+[![Travis Build Status](https://travis-ci.com/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}}.svg?branch=master)](https://travis-ci.com/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}})
 {% if cookiecutter.Include_Windows_continuous_integration == "y" -%}
 [![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/REPLACE_WITH_APPVEYOR_LINK/branch/master?svg=true)](https://ci.appveyor.com/project/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}}/branch/master)
 {% endif -%}


### PR DESCRIPTION
All new open source repositories use the same infrastructure as private ones: https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/