### PR TITLE
Manage testing with tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,7 +152,7 @@ install:
   - source install.travis
 
 script:
-  - pip install pyyaml
+  - pip install pyyaml travis-tox tox
   - python ../tests/run_yaml.py .travis.yml script script.travis
   - source script.travis
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ remove deployment platforms, or test with a different suite.
 * Pre-configured `setup.py` for installation and packaging
 * Pre-configured Window, Linux, and OSX continuous integration on AppVeyor and Travis-CI
 * Choice of dependency locations through `conda-forge`, default `conda`, or `pip` 
-* Basic testing structure with [PyTest](https://docs.pytest.org/en/latest/)
+* Basic testing structure with [tox](https://tox.readthedocs.io/en/latest/) and [PyTest](https://docs.pytest.org/en/latest/)
 * Automatic `git` initialization + tag
 * GitHub Hooks
 * Automatic package version control with [Versioneer](https://github.com/warner/python-versioneer)
@@ -73,7 +73,11 @@ To get started additional tests can be added to the `project/tests/` folder. Any
 included in the testing framework. While these can be added in anywhere in your directory structure, it is highly recommended to keep them
 contained within the `project/tests/` folder.
 
-Tests can be run with the `pytest -v` command. There are a number of additional command line arguments to 
+To tox have been added to allow us to test our packages in with various python versions
+and environments. The goal of tox is to allow us to isolate testing environment and make tests
+reproducible locally and on continuous integration.
+
+Tests can be run with the `tox` command. There are a number of additional command line arguments to
 [explore](https://docs.pytest.org/en/latest/usage.html).
 
 ### Continuous Integration
@@ -188,7 +192,7 @@ building your packages than the Conda tool, `conda-build`, will be. Depending on
 have conditions where `conda-build` takes 10-20 min to resolve, download, configure, and install all dependencies 
 *before your tests start*, whereas `pip` would do the same in about 5 min. It is also important to note that both 
 `pip` and `conda-build` are not *testing tools* in and of themselves; they are deployment and dependency resolution 
-tools.  For pure testing, we include other packages like [pytest](https://pytest.org).
+tools.  For pure testing, we include other packages like [tox](https://tox.readthedocs.io/en/latest/).
 
 From a deployment perspective, it is possible to deploy your package on both platforms, although doing so is beyond 
 the scope of this Cookiecutter. 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,6 @@ install:
 build: false
 
 test_script:
-  - pip install pyyaml
+  - pip install pyyaml tox
   - python ../tests/run_yaml.py appveyor.yml test_script script.appveyor.bat
   - .\script.appveyor.bat

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ Features
 * Pre-configured ``setup.py`` for installation and packaging
 * Pre-configured Window, Linux, and OSX continuous integration on AppVeyor and Travis-CI
 * Choice of dependency locations through ``conda-forge``, default ``conda``, or ``pip``
-* Basic testing structure with `PyTest <https://docs.pytest.org/en/latest/>`_
+* Basic testing structure with `tox <https://tox.readthedocs.io/en/latest/>` and `PyTest <https://docs.pytest.org/en/latest/>`_
 * Automatic ``git`` initialization + tag
 * GitHub Hooks
 * Automatic package version control with `Versioneer <https://github.com/warner/python-versioneer>`_
@@ -96,7 +96,11 @@ To get started additional tests can be added to the ``project/tests/`` folder. A
 included in the testing framework. While these can be added in anywhere in your directory structure, it is highly recommended to keep them
 contained within the ``project/tests/`` folder.
 
-Tests can be run with the ``pytest -v`` command. There are a number of additional command line arguments to
+To tox have been added to allow us to test our packages in with various python versions
+and environments. The goal of tox is to allow us to isolate testing environment and make tests
+reproducible locally and on continuous integration.
+
+Tests can be run with the ``tox`` command. There are a number of additional command line arguments to
 `explore <https://docs.pytest.org/en/latest/usage.html>`_.
 
 Continuous Integration

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -41,7 +41,7 @@ before_install:
 install:
 {% if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
     # Install the package locally
-  - pip install -U pytest pytest-cov codecov
+  - pip install -U tox-travis tox pytest-cov codecov
   - pip install -e .
 {% else %}
     # Create test environment for package
@@ -53,7 +53,7 @@ install:
 {% endif %}
 
 script:
-  - pytest -v --cov={{cookiecutter.repo_name}} {{cookiecutter.repo_name}}/tests/
+  - tox
 
 notifications:
     email: false

--- a/{{cookiecutter.repo_name}}/appveyor.yml
+++ b/{{cookiecutter.repo_name}}/appveyor.yml
@@ -47,13 +47,13 @@ install:
   {% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
     # Install the package locally
   - pip install --upgrade pip setuptools
-  - pip install pytest pytest-cov codecov
+  - pip install tox pytest-cov codecov
   - pip install -e .
   {% endif %}
 build: false
 
 test_script:
-  - pytest -v --cov={{cookiecutter.repo_name}} {{cookiecutter.repo_name}}\\tests
+  - tox
 
 on_success:
   - codecov

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -2,15 +2,10 @@
 {{cookiecutter.project_name}}
 {{cookiecutter.description}}
 """
-import sys
 from setuptools import setup, find_packages
 import versioneer
 
 short_description = __doc__.split("\n")
-
-# from https://github.com/pytest-dev/pytest-runner#conditional-requirement
-needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 try:
     with open("README.md", "r") as handle:
@@ -40,9 +35,6 @@ setup(
     # Customize MANIFEST.in if the general case does not suit your needs
     # Comment out this line to prevent the files from being packaged with your software
     include_package_data=True,
-
-    # Allows `setup.py test` to work correctly with pytest
-    setup_requires=[] + pytest_runner,
 
     # Additional entries you may want simply uncomment the lines you want and fill in the data
     # url='http://www.my_package.com',  # Website

--- a/{{cookiecutter.repo_name}}/tox.ini
+++ b/{{cookiecutter.repo_name}}/tox.ini
@@ -1,0 +1,31 @@
+[tox]
+minversion = 3.2.0
+envlist = py36,py37
+ignore_basepython_conflict = True
+
+[testenv]
+basepython = python3
+usedevelop = True
+deps = nose
+       pytest
+       pytest-cov
+commands = nosetests
+
+[testenv:pep8]
+basepython = python3.6
+deps = flake8
+       flake8-import-order
+       flake8-blind-except
+       flake8-builtins
+       flake8-docstrings
+       flake8-rst-docstrings
+       flake8-logging-format
+commands = flake8
+
+[flake8]
+exclude = .tox,.eggs
+show-source = true
+ignore = D100,D101,D102,D103,D104
+
+[travis]
+python = 3.6: py36, pep8


### PR DESCRIPTION
These changes aim to manage tests by using tox.

tox provide a command line driven CI frontend and development
task automation tool.

The benefits to us tox are:
- manage several task automatically (see the examples list below)
- run tests and tasks in dedicated and isolated virtual environments
- standardize the way users contribute to our projects by introducing
dedicated commands
- ensure that execution would be reproducible and standardized between
environments (local, CI, etc...)

It could allow us to define several tasks to run which could help us
to improve the project quality and stability by introducing
specific and reproductible tasks like:
- test execution
- linters execution
- auto formating code by using [black](https://github.com/psf/black)
- doc generation
- release notes generation
- etc

These changes drop the tests from the packaging, in other words
pytest is no longer needed to build our packages, it's only installed
and used for testing and during development lifecycle.

tox is a mainstream project used widely in by python community
it could help us to standardize the way we tests and we develop
on kinoml.

Also these changes could help us to reduce the cost to contribute
to this project by providing mainstream features.