### PR TITLE
Run pytest as module

### DIFF
--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -72,7 +72,7 @@ jobs:
       shell: bash -l {0}
 {% endif %}
       run: |
-        pytest -v --cov={{ cookiecutter.repo_name }} --cov-report=xml --color=yes {{ cookiecutter.repo_name }}/tests/
+        python -m pytest -v --cov={{ cookiecutter.repo_name }} --cov-report=xml --color=yes {{ cookiecutter.repo_name }}/tests/
 
     - name: CodeCov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
I just spent a few hours debugging a `ModuleNotFoundError` with GitHub Actions. My installed module was not picked up by `pytest` for some reason and running `pytest` as a module solved the issue. 

Since my GitHub Action was strongly inspired by this one, I think running `pytest` as a module could be a safer option here as well?