### PR TITLE
Remove default.profraw if its found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# profraw files from LLVM? Unclear exactly what triggers this
+# There are reports this comes from LLVM profiling, but also Xcode 9.
+*profraw

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ matrix:
 
 before_install:
     # Make sure pip is around, on OSX Travis we have to do some shenanigans
-  - if [[ "$TRAVIS_OS_NAME" == "osx" && ! $(command -v pip) ]]; then source cihelpers/osx_travis_py_helper.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then source cihelpers/osx_travis_py_helper.sh; fi
 
     # Install a few requirements
   - pip install pyyaml cookiecutter

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ environment:
 
 
 install:
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     # Install a few requirements
   - pip install pyyaml cookiecutter
 

--- a/cihelpers/osx_travis_py_helper.sh
+++ b/cihelpers/osx_travis_py_helper.sh
@@ -18,7 +18,7 @@ HOMEBREW_NO_AUTO_UPDATE=1 brew upgrade pyenv
 # Pyenv requires minor revision, get the latest
 PYENV_VERSION=$(pyenv install --list |grep $PYTHON_VER | sed -n "s/^[ \t]*\(${PYTHON_VER}\.*[0-9]*\).*/\1/p" | tail -n 1)
 # Install version
-pyenv install $PYENV_VERSION
+pyenv install -f $PYENV_VERSION
 # Use version for this
 pyenv global $PYENV_VERSION
 # Setup up path shims

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -35,7 +35,10 @@ def invoke_shell(command, expected_error=True, print_output=True):
 
 
 def git_init_and_tag():
-    """Invoke the initial git and tag with 0.0.0 to make an initial version for Versioneer to ID if not already in a git repository."""
+    """
+    Invoke the initial git and tag with 0.0.0 to make an initial version for
+    Versioneer to ID if not already in a git repository.
+    """
     
     # Check if we are in a git repository
     directory_status = invoke_shell("git status", expected_error=True, print_output=False)
@@ -56,7 +59,8 @@ def git_init_and_tag():
         if not version:
             invoke_shell("git tag 0.0.0")
     else:
-        print("\ngit repository detected. CookieCutter files have been created in {{ cookiecutter.repo_name }} directory.")
+        print("\ngit repository detected. "
+              "CookieCutter files have been created in {{ cookiecutter.repo_name }} directory.")
 
 
 def select_continuous_integration_provider():
@@ -73,5 +77,18 @@ def select_continuous_integration_provider():
         shutil.rmtree(".github/workflows")
 
 
+def random_file_cleanup_removal():
+    """Remove random files which can be generated under certain conditions"""
+    random_file_list = [
+        "default.profraw",  # Remove default.profraw files, see #105
+    ]
+    for random_file in random_file_list:
+        try:
+            os.remove(random_file)
+        except FileNotFoundError:
+            pass
+
+
 select_continuous_integration_provider()
+random_file_cleanup_removal()
 git_init_and_tag()

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -100,3 +100,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# profraw files from LLVM? Unclear exactly what triggers this
+# There are reports this comes from LLVM profiling, but also Xcode 9.
+*profraw

--- a/{{cookiecutter.repo_name}}/appveyor.yml
+++ b/{{cookiecutter.repo_name}}/appveyor.yml
@@ -21,8 +21,8 @@ environment:
 
 install:
     # Make sure pip is around
-  - python -m ensurepip
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - python -m ensurepip
   {% if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
   {%- if cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' %}
     # Add conda-forge channel

--- a/{{cookiecutter.repo_name}}/devtools/travis-ci/before_install.sh
+++ b/{{cookiecutter.repo_name}}/devtools/travis-ci/before_install.sh
@@ -42,7 +42,7 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     # Pyenv requires minor revision, get the latest
     PYENV_VERSION=$(pyenv install --list |grep $PYTHON_VER | sed -n "s/^[ \t]*\(${PYTHON_VER}\.*[0-9]*\).*/\1/p" | tail -n 1)
     # Install version
-    pyenv install $PYENV_VERSION
+    pyenv install -f $PYENV_VERSION
     # Use version for this
     pyenv global $PYENV_VERSION
     # Setup up path shims


### PR DESCRIPTION
Fixes #105

There are not too much data on exactly what this is, or what conditions
generate it. I cannot reproduce this locally, but users are reporting
it, so I added a function to remove if found and added to the .gitignore

From what I can read, its some profiling data output from the LLVM
compiler for code coverage. There are some consistent reports about it
being in Xcode 9 only, but not enough to really pin this down.

In any case, this should prevent the file from sticking around if its
there.