### PR TITLE
add .vscode/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 # profraw files from LLVM? Unclear exactly what triggers this
 # There are reports this comes from LLVM profiling, but also Xcode 9.
 *profraw
+
+# VS Code project settings
+.vscode/

--- a/{{cookiecutter.repo_name}}/.gitignore
+++ b/{{cookiecutter.repo_name}}/.gitignore
@@ -104,3 +104,6 @@ ENV/
 # profraw files from LLVM? Unclear exactly what triggers this
 # There are reports this comes from LLVM profiling, but also Xcode 9.
 *profraw
+
+# VS Code project settings
+.vscode/


### PR DESCRIPTION
When VS Code used for project editing, changing the VS Code project settings will cause VS Code write the new settings to .vscode directory. Therefore untrack this directory.