### PR TITLE
Update URL of setup-miniconda action

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ links below. We do not implement them for this Cookiecutter, but they can be add
 
 _Note: Support for GitHub Actions is still experimental and not yet documented_.
 
-As of version 1.3, we provide preconfigured workflows for [GitHub Actions](https://github.com/features/actions), with support for Linux, MacOS and Windows. Conda support is possible thanks to the excellent [@goanpeca's `setup-miniconda` action](https://github.com/goanpeca/setup-miniconda). We encourage you read its documentation for further details.
+As of version 1.3, we provide preconfigured workflows for [GitHub Actions](https://github.com/features/actions), with support for Linux, MacOS and Windows. Conda support is possible thanks to the excellent [@conda-incubator's `setup-miniconda` action](https://github.com/conda-incubator/setup-miniconda). We encourage you read its documentation for further details.
 
 ### Documentation
 Make a [ReadTheDocs](https://readthedocs.org) account and turn on the git hook. Although you can manually make the

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -38,8 +38,8 @@ jobs:
       run: |
         python -m pip install -U pytest pytest-cov codecov
 {% else %}
-    # More info on options: https://github.com/goanpeca/setup-miniconda
-    - uses: goanpeca/setup-miniconda@v1
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - uses: conda-incubator/setup-miniconda@v1
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
         environment-file: devtools/conda-envs/test_env.yaml


### PR DESCRIPTION
See https://github.com/conda-incubator/setup-miniconda/issues/70 for context. The developer of the action moved it from personal ownership to an organization and we found that the redirect was not automatically happening at the API level (whereas it was fine with HTTP). A GitHub employee claims the API redirection has been fixed, and the original developer also forked it back as a stopgap, but we should update this for its current home nonetheless.