### PR TITLE
add rtd support to cookiecutter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.7
         - CI_PROVIDER=2  # Travis+Appveyor
+        - RTD=2
     - os: osx
       language: generic
       env:
@@ -18,6 +19,7 @@ matrix:
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.7
         - CI_PROVIDER=2
+        - RTD=1
     - os: osx
       language: generic
       env:
@@ -25,6 +27,7 @@ matrix:
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.7
         - CI_PROVIDER=2
+        - RTD=1
     - os: osx
       language: generic
       env:
@@ -32,6 +35,7 @@ matrix:
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.7
         - CI_PROVIDER=1  # Travis only
+        - RTD=1
     - os: osx
       language: generic
       env:
@@ -39,6 +43,7 @@ matrix:
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.6
         - CI_PROVIDER=2
+        - RTD=1
     - os: osx
       language: generic
       env:
@@ -46,6 +51,7 @@ matrix:
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.6
         - CI_PROVIDER=2
+        - RTD=1
     - os: osx
       language: generic
       env:
@@ -53,6 +59,7 @@ matrix:
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.6
         - CI_PROVIDER=2
+        - RTD=1
     - os: osx
       language: generic
       env:
@@ -60,6 +67,7 @@ matrix:
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.6
         - CI_PROVIDER=1
+        - RTD=1
 
     # Pin Xenial for 3.7
     - os: linux
@@ -70,6 +78,7 @@ matrix:
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.7
         - CI_PROVIDER=2
+        - RTD=1
 
     - os: linux
       dist: xenial
@@ -79,6 +88,7 @@ matrix:
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.7
         - CI_PROVIDER=2
+        - RTD=1
 
     - os: linux
       dist: xenial
@@ -88,6 +98,7 @@ matrix:
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.7
         - CI_PROVIDER=2
+        - RTD=1
 
     - os: linux
       dist: xenial
@@ -97,6 +108,7 @@ matrix:
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.7
         - CI_PROVIDER=1
+        - RTD=1
 
     - os: linux
       python: 3.6
@@ -105,6 +117,7 @@ matrix:
         - DEPEND_SOURCE=1
         - PYTHON_VER=3.6
         - CI_PROVIDER=2
+        - RTD=1
 
     - os: linux
       python: 3.6
@@ -113,6 +126,7 @@ matrix:
         - DEPEND_SOURCE=2
         - PYTHON_VER=3.6
         - CI_PROVIDER=2
+        - RTD=1
 
     - os: linux
       python: 3.6
@@ -121,6 +135,7 @@ matrix:
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.6
         - CI_PROVIDER=2
+        - RTD=1
 
     - os: linux
       python: 3.6
@@ -129,6 +144,7 @@ matrix:
         - DEPEND_SOURCE=3
         - PYTHON_VER=3.6
         - CI_PROVIDER=1
+        - RTD=1
 
 before_install:
     # Make sure pip is around, on OSX Travis we have to do some shenanigans
@@ -138,7 +154,7 @@ before_install:
   - pip install pyyaml cookiecutter
 
     # Build out the cookiecutter from settings
-  - python tests/setup_cookiecutter.py default_project $LICENSE $DEPEND_SOURCE $CI_PROVIDER
+  - python tests/setup_cookiecutter.py default_project $LICENSE $DEPEND_SOURCE $CI_PROVIDER $RTD
 
     # Change into new project directory
   - cd default_project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
       CI_PROVIDER: 2  # Travis+Appveyor
+      RTD: 1
 
     - PYTHON: "C:\\Miniconda37-x64"
       LICENSE: 2
@@ -14,6 +15,7 @@ environment:
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       CI_PROVIDER: 2
+      RTD: 2
 
     - PYTHON: "C:\\Python36-x64"
       LICENSE: 1
@@ -21,6 +23,7 @@ environment:
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
       CI_PROVIDER: 2
+      RTD: 2
 
 
 
@@ -35,7 +38,7 @@ install:
   - git config --global core.autocrlf true
 
     # Build out the cookiecutter from settings
-  - python tests/setup_cookiecutter.py default_project %LICENSE% %DEPEND_SOURCE% %CI_PROVIDER%
+  - python tests/setup_cookiecutter.py default_project %LICENSE% %DEPEND_SOURCE% %CI_PROVIDER% %RTD%
 
     # Change into new project directory
   - ps: cd default_project

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
     "author_email": "Your email (or your organization/company/team)",
     "description": "A short description of the project.",
     "open_source_license": [
+
         "MIT",
         "BSD-3-Clause",
         "LGPLv3",
@@ -21,5 +22,7 @@
         "Travis+AppVeyor",
         "GitHub Actions (experimental)"
     ],
+    
+    "include_ReadTheDocs": ["y", "n"],
     "_cms_cc_version": 1.3
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -76,6 +76,12 @@ def select_continuous_integration_provider():
     elif provider == "travis+appveyor":
         shutil.rmtree(".github/workflows")
 
+def remove_rtd():
+    include_rtd = '{{ cookiecutter.include_ReadTheDocs }}'
+    if include_rtd == "n":
+        rtd_env = os.path.join("docs", "requirements.yaml")
+        os.remove('readthedocs.yml')
+        os.remove(rtd_env)
 
 def random_file_cleanup_removal():
     """Remove random files which can be generated under certain conditions"""
@@ -88,7 +94,7 @@ def random_file_cleanup_removal():
         except FileNotFoundError:
             pass
 
-
+remove_rtd()
 select_continuous_integration_provider()
 random_file_cleanup_removal()
 git_init_and_tag()

--- a/tests/setup_cookiecutter.py
+++ b/tests/setup_cookiecutter.py
@@ -9,6 +9,7 @@ project = sys.argv[1]
 lic = sys.argv[2]
 depend = sys.argv[3]
 provider = sys.argv[4]
+rtd = sys.argv[5]
 print("Options: open_source_license=%s, dependency_source=%s, ci_provider=%s" % (lic, depend, provider))
 
 # Setup the options
@@ -20,7 +21,8 @@ options = [project, # Repo name
            "", # Description
            lic, # License
            depend, # Dependency
-           provider] # ci_provider
+           provider, # ci_provider
+           rtd] 
 
 # Open a thread
 p = Popen(["cookiecutter", "."], stdin=PIPE, stdout=PIPE)

--- a/{{cookiecutter.repo_name}}/docs/README.md
+++ b/{{cookiecutter.repo_name}}/docs/README.md
@@ -20,3 +20,10 @@ make html
 
 The compiled docs will be in the `_build` directory and can be viewed by opening `index.html` (which may itself 
 be inside a directory called `html/` depending on what version of Sphinx is installed).
+
+{% if (cookiecutter.include_ReadTheDocs == 'y') %}
+A configuration file for [Read The Docs](https://readthedocs.org/) (readthedocs.yaml) is included in the top level of the repository. To use Read the Docs to host your documentation, go to https://readthedocs.org/ and connect this repository. You may need to change your default branch to `main` under Advanced Settings for the project.
+
+If you would like to use Read The Docs with `autodoc` (included automatically) and your package has dependencies, you will need to include those dependencies in your documentation yaml file (`docs/requirements.yaml`).
+
+{% endif %}

--- a/{{cookiecutter.repo_name}}/docs/requirements.yaml
+++ b/{{cookiecutter.repo_name}}/docs/requirements.yaml
@@ -1,0 +1,15 @@
+name: docs
+channels:
+dependencies:
+    # Base depends
+  - python
+  - pip
+
+{% if cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback' %}
+  # Pip-only installs
+  - pip:
+{% else %}
+
+    # Pip-only installs
+  #- pip:
+{% endif %}

--- a/{{cookiecutter.repo_name}}/readthedocs.yml
+++ b/{{cookiecutter.repo_name}}/readthedocs.yml
@@ -1,0 +1,15 @@
+# readthedocs.yml
+
+version: 2
+
+build:
+  image: latest
+
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+
+conda:
+  environment: docs/requirements.yaml


### PR DESCRIPTION
This is a version of #93 which has a cleaner history

This PR adds creation of files related to hosting documentation on RTD.

Currently, docs use autodoc to pull docstrings from functions. This will work both locally and on RTD if the package has no dependencies. However, if the package has dependencies, RTD needs a yaml file which points to a yaml for a conda environment where dependencies are specified.

This PR implements the following changes

 - A RTD yaml and environment file are added
 - The option to create a RTD yaml and documentation environment file are added to the CookieCutter prompt. If 'no' is selected, the files outlined above are removed.
- Some additional instructions are added to `docs/README.md` if RTD support is chosen.