### PR TITLE
Test the GitHub Actions Workflows

### DIFF
--- a/.github/reference-workflows/CI_1_1_3_1.yaml
+++ b/.github/reference-workflows/CI_1_1_3_1.yaml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - uses: conda-incubator/setup-miniconda@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/conda-envs/test_env.yaml
+
+        channels: conda-forge,defaults
+
+        activate-environment: test
+        auto-update-conda: true
+        auto-activate-base: false
+        show-channel-urls: true
+
+    - name: Install package
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+      run: |
+        python -m pip install . --no-deps
+        conda list
+
+
+    - name: Run tests
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+
+      run: |
+        pytest -v --cov=prj_1_1_3_1 --cov-report=xml --color=yes prj_1_1_3_1/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_1_3_1.yaml
+++ b/.github/reference-workflows/CI_1_1_3_1.yaml
@@ -42,7 +42,7 @@ jobs:
         channels: conda-forge,defaults
 
         activate-environment: test
-        auto-update-conda: true
+        auto-update-conda: false
         auto-activate-base: false
         show-channel-urls: true
 

--- a/.github/reference-workflows/CI_1_1_3_2.yaml
+++ b/.github/reference-workflows/CI_1_1_3_2.yaml
@@ -42,7 +42,7 @@ jobs:
         channels: conda-forge,defaults
 
         activate-environment: test
-        auto-update-conda: true
+        auto-update-conda: false
         auto-activate-base: false
         show-channel-urls: true
 

--- a/.github/reference-workflows/CI_1_1_3_2.yaml
+++ b/.github/reference-workflows/CI_1_1_3_2.yaml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - uses: conda-incubator/setup-miniconda@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/conda-envs/test_env.yaml
+
+        channels: conda-forge,defaults
+
+        activate-environment: test
+        auto-update-conda: true
+        auto-activate-base: false
+        show-channel-urls: true
+
+    - name: Install package
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+      run: |
+        python -m pip install . --no-deps
+        conda list
+
+
+    - name: Run tests
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+
+      run: |
+        pytest -v --cov=prj_1_1_3_2 --cov-report=xml --color=yes prj_1_1_3_2/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_2_3_1.yaml
+++ b/.github/reference-workflows/CI_1_2_3_1.yaml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - uses: conda-incubator/setup-miniconda@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/conda-envs/test_env.yaml
+
+        activate-environment: test
+        auto-update-conda: true
+        auto-activate-base: false
+        show-channel-urls: true
+
+    - name: Install package
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+      run: |
+        python -m pip install . --no-deps
+        conda list
+
+
+    - name: Run tests
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+
+      run: |
+        pytest -v --cov=prj_1_2_3_1 --cov-report=xml --color=yes prj_1_2_3_1/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_2_3_1.yaml
+++ b/.github/reference-workflows/CI_1_2_3_1.yaml
@@ -40,7 +40,7 @@ jobs:
         environment-file: devtools/conda-envs/test_env.yaml
 
         activate-environment: test
-        auto-update-conda: true
+        auto-update-conda: false
         auto-activate-base: false
         show-channel-urls: true
 

--- a/.github/reference-workflows/CI_1_2_3_2.yaml
+++ b/.github/reference-workflows/CI_1_2_3_2.yaml
@@ -40,7 +40,7 @@ jobs:
         environment-file: devtools/conda-envs/test_env.yaml
 
         activate-environment: test
-        auto-update-conda: true
+        auto-update-conda: false
         auto-activate-base: false
         show-channel-urls: true
 

--- a/.github/reference-workflows/CI_1_2_3_2.yaml
+++ b/.github/reference-workflows/CI_1_2_3_2.yaml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - uses: conda-incubator/setup-miniconda@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/conda-envs/test_env.yaml
+
+        activate-environment: test
+        auto-update-conda: true
+        auto-activate-base: false
+        show-channel-urls: true
+
+    - name: Install package
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+      run: |
+        python -m pip install . --no-deps
+        conda list
+
+
+    - name: Run tests
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+
+      run: |
+        pytest -v --cov=prj_1_2_3_2 --cov-report=xml --color=yes prj_1_2_3_2/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_3_3_1.yaml
+++ b/.github/reference-workflows/CI_1_3_3_1.yaml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    - name: Install testing dependencies
+      shell: bash
+      run: |
+        python -m pip install -U pytest pytest-cov codecov
+
+    - name: Install package
+
+      shell: bash
+      run: |
+        python -m pip install .
+
+
+    - name: Run tests
+
+      shell: bash
+
+      run: |
+        pytest -v --cov=prj_1_3_3_1 --cov-report=xml --color=yes prj_1_3_3_1/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_3_3_1.yaml
+++ b/.github/reference-workflows/CI_1_3_3_1.yaml
@@ -33,7 +33,7 @@ jobs:
         ulimit -a
 
 
-    - name: Install testing dependencies
+    - name: Testing Dependencies
       shell: bash
       run: |
         python -m pip install -U pytest pytest-cov codecov

--- a/.github/reference-workflows/CI_1_3_3_2.yaml
+++ b/.github/reference-workflows/CI_1_3_3_2.yaml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    - name: Install testing dependencies
+      shell: bash
+      run: |
+        python -m pip install -U pytest pytest-cov codecov
+
+    - name: Install package
+
+      shell: bash
+      run: |
+        python -m pip install .
+
+
+    - name: Run tests
+
+      shell: bash
+
+      run: |
+        pytest -v --cov=prj_1_3_3_2 --cov-report=xml --color=yes prj_1_3_3_2/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_3_3_2.yaml
+++ b/.github/reference-workflows/CI_1_3_3_2.yaml
@@ -33,7 +33,7 @@ jobs:
         ulimit -a
 
 
-    - name: Install testing dependencies
+    - name: Testing Dependencies
       shell: bash
       run: |
         python -m pip install -U pytest pytest-cov codecov

--- a/.github/reference-workflows/CI_2_1_3_1.yaml
+++ b/.github/reference-workflows/CI_2_1_3_1.yaml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - uses: conda-incubator/setup-miniconda@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/conda-envs/test_env.yaml
+
+        channels: conda-forge,defaults
+
+        activate-environment: test
+        auto-update-conda: true
+        auto-activate-base: false
+        show-channel-urls: true
+
+    - name: Install package
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+      run: |
+        python -m pip install . --no-deps
+        conda list
+
+
+    - name: Run tests
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+
+      run: |
+        pytest -v --cov=prj_2_1_3_1 --cov-report=xml --color=yes prj_2_1_3_1/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_2_1_3_1.yaml
+++ b/.github/reference-workflows/CI_2_1_3_1.yaml
@@ -42,7 +42,7 @@ jobs:
         channels: conda-forge,defaults
 
         activate-environment: test
-        auto-update-conda: true
+        auto-update-conda: false
         auto-activate-base: false
         show-channel-urls: true
 

--- a/.github/reference-workflows/CI_2_1_3_2.yaml
+++ b/.github/reference-workflows/CI_2_1_3_2.yaml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - uses: conda-incubator/setup-miniconda@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/conda-envs/test_env.yaml
+
+        channels: conda-forge,defaults
+
+        activate-environment: test
+        auto-update-conda: true
+        auto-activate-base: false
+        show-channel-urls: true
+
+    - name: Install package
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+      run: |
+        python -m pip install . --no-deps
+        conda list
+
+
+    - name: Run tests
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+
+      run: |
+        pytest -v --cov=prj_2_1_3_2 --cov-report=xml --color=yes prj_2_1_3_2/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_2_1_3_2.yaml
+++ b/.github/reference-workflows/CI_2_1_3_2.yaml
@@ -42,7 +42,7 @@ jobs:
         channels: conda-forge,defaults
 
         activate-environment: test
-        auto-update-conda: true
+        auto-update-conda: false
         auto-activate-base: false
         show-channel-urls: true
 

--- a/.github/reference-workflows/CI_2_2_3_1.yaml
+++ b/.github/reference-workflows/CI_2_2_3_1.yaml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - uses: conda-incubator/setup-miniconda@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/conda-envs/test_env.yaml
+
+        activate-environment: test
+        auto-update-conda: true
+        auto-activate-base: false
+        show-channel-urls: true
+
+    - name: Install package
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+      run: |
+        python -m pip install . --no-deps
+        conda list
+
+
+    - name: Run tests
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+
+      run: |
+        pytest -v --cov=prj_2_2_3_1 --cov-report=xml --color=yes prj_2_2_3_1/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_2_2_3_1.yaml
+++ b/.github/reference-workflows/CI_2_2_3_1.yaml
@@ -40,7 +40,7 @@ jobs:
         environment-file: devtools/conda-envs/test_env.yaml
 
         activate-environment: test
-        auto-update-conda: true
+        auto-update-conda: false
         auto-activate-base: false
         show-channel-urls: true
 

--- a/.github/reference-workflows/CI_2_2_3_2.yaml
+++ b/.github/reference-workflows/CI_2_2_3_2.yaml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    # More info on options: https://github.com/conda-incubator/setup-miniconda
+    - uses: conda-incubator/setup-miniconda@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        environment-file: devtools/conda-envs/test_env.yaml
+
+        activate-environment: test
+        auto-update-conda: true
+        auto-activate-base: false
+        show-channel-urls: true
+
+    - name: Install package
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+      run: |
+        python -m pip install . --no-deps
+        conda list
+
+
+    - name: Run tests
+
+      # conda setup requires this special shell
+      shell: bash -l {0}
+
+      run: |
+        pytest -v --cov=prj_2_2_3_2 --cov-report=xml --color=yes prj_2_2_3_2/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_2_2_3_2.yaml
+++ b/.github/reference-workflows/CI_2_2_3_2.yaml
@@ -40,7 +40,7 @@ jobs:
         environment-file: devtools/conda-envs/test_env.yaml
 
         activate-environment: test
-        auto-update-conda: true
+        auto-update-conda: false
         auto-activate-base: false
         show-channel-urls: true
 

--- a/.github/reference-workflows/CI_2_3_3_1.yaml
+++ b/.github/reference-workflows/CI_2_3_3_1.yaml
@@ -33,7 +33,7 @@ jobs:
         ulimit -a
 
 
-    - name: Install testing dependencies
+    - name: Testing Dependencies
       shell: bash
       run: |
         python -m pip install -U pytest pytest-cov codecov

--- a/.github/reference-workflows/CI_2_3_3_1.yaml
+++ b/.github/reference-workflows/CI_2_3_3_1.yaml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    - name: Install testing dependencies
+      shell: bash
+      run: |
+        python -m pip install -U pytest pytest-cov codecov
+
+    - name: Install package
+
+      shell: bash
+      run: |
+        python -m pip install .
+
+
+    - name: Run tests
+
+      shell: bash
+
+      run: |
+        pytest -v --cov=prj_2_3_3_1 --cov-report=xml --color=yes prj_2_3_3_1/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_2_3_3_2.yaml
+++ b/.github/reference-workflows/CI_2_3_3_2.yaml
@@ -33,7 +33,7 @@ jobs:
         ulimit -a
 
 
-    - name: Install testing dependencies
+    - name: Testing Dependencies
       shell: bash
       run: |
         python -m pip install -U pytest pytest-cov codecov

--- a/.github/reference-workflows/CI_2_3_3_2.yaml
+++ b/.github/reference-workflows/CI_2_3_3_2.yaml
@@ -1,0 +1,60 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+jobs:
+  test:
+    name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Additional info about the build
+      shell: bash
+      run: |
+        uname -a
+        df -h
+        ulimit -a
+
+
+    - name: Install testing dependencies
+      shell: bash
+      run: |
+        python -m pip install -U pytest pytest-cov codecov
+
+    - name: Install package
+
+      shell: bash
+      run: |
+        python -m pip install .
+
+
+    - name: Run tests
+
+      shell: bash
+
+      run: |
+        pytest -v --cov=prj_2_3_3_2 --cov-report=xml --color=yes prj_2_3_3_2/tests/
+
+    - name: CodeCov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/README.md
+++ b/.github/reference-workflows/README.md
@@ -1,0 +1,10 @@
+# Reference GitHub Actions Workflows
+
+This directory contains the reference workflows for all of the GitHub Actions generated from the Cookiecutter
+
+Another GHA Workflow validates that the outputs of this folder match the outputs of the Cookiecutter
+
+That same workflow also has an approximate implementation of the GHA to at least try to emulate its steps.
+
+To regenerate the references, run the "regenerate_references.sh" script from the "tests" directory in the root of the 
+Cookiecutter. There is a bit of manual adjustment required if the scripts change, but this is at least a simple test.

--- a/.github/workflows/verify-ghas.yaml
+++ b/.github/workflows/verify-ghas.yaml
@@ -1,0 +1,272 @@
+name: Pseudo Validate GHA Output
+
+# Approximation of the GHA "on" block
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    branches:
+      - "master"
+  schedule:
+    # Nightly tests run on master by default:
+    #   Scheduled workflows run on the latest commit on the default or base branch.
+    #   (from https://help.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
+    - cron: "0 0 * * *"
+
+# Custom global env block
+env:
+  licenses: [1, 2]
+  depend-sources: [1, 2, 3]
+  ci-providers: 3  # This should always be GHA and only GHA
+  rtd: [1, 2]
+
+jobs:
+  generate-cookiecutter:
+    name: "Create the Cookiecutter artifacts"
+    strategy:
+      matrix:
+        license: ${{ env.licenses }}
+        depend-source: ${{ env.depend-sources }}
+        ci-provider: ${{ env.ci-providers }}
+        rtd: ${{ env.rtd }}
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: "Install dependencies"
+        shell: bash
+        run: |
+          python -m pip install -U pyyaml cookiecutter
+
+      - name: "Construct Cookiecutter"
+        shell: bash
+        run: |
+          python tests/setup_cookiecutter.py built_cookie_{{ '${{ matrix.license }}' }}_{{ '${{ matrix.depend-source }}' }}_{{ '${{ matrix.ci-provider }}' }}_{{ '${{ matrix.rtd }}' }} {{ '${{ matrix.license }}' }} {{ '${{ matrix.depend-source }}' }} {{ '${{ matrix.ci-provider }}' }} {{ '${{ matrix.rtd }}' }}
+
+      - name: "Upload outputs to artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: cookiecutter_outputs
+          path: built_cookie_{{ '${{ matrix.license }}' }}_{{ '${{ matrix.depend-source }}' }}_{{ '${{ matrix.ci-provider }}' }}_{{ '${{ matrix.rtd }}' }}
+
+  compare-action-output:
+    name: "Compare GHA Output"
+    needs: "generate-cookiecutter"
+    strategy:
+      matrix:
+        license: ${{ env.licenses }}
+        depend-source: ${{ env.depend-sources }}
+        ci-provider: ${{ env.ci-providers }}
+        rtd: ${{ env.rtd }}
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: "Fetch Cookiecutter Builds"
+        uses: actions/download-artifact@v2
+        with:
+          name: cookiecutter_outputs
+
+      - name: "Compare CI files to reference"
+        shell: bash
+        run: |
+          COMBO="{{ '${{ matrix.license }}' }}_{{ '${{ matrix.depend-source }}' }}_{{ '${{ matrix.ci-provider }}' }}_{{ '${{ matrix.rtd }}' }}"
+          mv built_cookie_$COMBO/.github/workflows/CI.yaml CI_$COMBO.yaml
+          COMPARE=$(diff CI_$COMBO.yaml .github/reference-workflows/CI_$COMBO.yaml)
+          if [[ ! -z $COMPARE ]]
+          then
+              echo "CI_$COMBO.yaml differs from reference!"
+              echo $COMPARE
+              exit 1
+
+
+  conda-forge-dep:
+    needs: "generate-cookiecutter"
+    name: Test CF (Approx) on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:  # Approximate strategy, uses a few other options
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+        license: 1  # Nonstandard
+        rtd: ${{ env.rtd }}  # Nonstandard
+    steps:
+      # - uses: actions/checkout@v1  # This isn't necessary here
+
+      - name: "Fetch Cookiecutter Builds"
+        uses: actions/download-artifact@v2
+        with:
+          name: cookiecutter_outputs
+
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
+
+      - name: "Change directory"  # Have to CD here to make sure this works
+        shell: bash
+        run: |
+          cd built_cookie_{{ '${{ matrix.license }}' }}_1_3_{{ '${{ matrix.rtd }}' }}
+
+      # More info on options: https://github.com/conda-incubator/setup-miniconda
+      - uses: conda-incubator/setup-miniconda@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          environment-file: devtools/conda-envs/test_env.yaml
+
+          channels: conda-forge,defaults
+
+          activate-environment: test
+          auto-update-conda: true
+          auto-activate-base: false
+          show-channel-urls: true
+
+      - name: Install package
+
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          python -m pip install . --no-deps
+          conda list
+
+
+      - name: Run tests
+
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=built_cookie_{ '${{ matrix.license }}' }}_1_${{ env.ci-providers }}_{{ '${{ matrix.rtd }}' }} --cov-report=xml --color=yes built_cookie_{{ '${{ matrix.license }}' }}_1_${{ env.ci-providers }}_{{ '${{ matrix.rtd }}' }}/tests/
+
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+
+
+  conda-defaults-dep:
+    needs: "generate-cookiecutter"
+    name: Test Conda Defaults (Approx) on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:  # Approximate strategy, uses a few other options
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+        license: 1  # Nonstandard
+        rtd: ${{ env.rtd }}  # Nonstandard
+
+    steps:
+      # - uses: actions/checkout@v1  # This isn't necessary here
+
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
+
+      - name: "Fetch Cookiecutter Builds"
+        uses: actions/download-artifact@v2
+        with:
+          name: cookiecutter_outputs
+
+      - name: "Change directory"  # Have to CD here to make sure this works
+        shell: bash
+        run: |
+          cd built_cookie_{{ '${{ matrix.license }}' }}_2_${{ env.ci-providers }}_{{ '${{ matrix.rtd }}' }}
+
+      # More info on options: https://github.com/conda-incubator/setup-miniconda
+      - uses: conda-incubator/setup-miniconda@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          environment-file: devtools/conda-envs/test_env.yaml
+
+          activate-environment: test
+          auto-update-conda: true
+          auto-activate-base: false
+          show-channel-urls: true
+
+      - name: Install package
+
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          python -m pip install . --no-deps
+          conda list
+
+
+      - name: Run tests
+
+        # conda setup requires this special shell
+        shell: bash -l {0}
+
+        run: |
+          pytest -v --cov=built_cookie_{ '${{ matrix.license }}' }}_2_${{ env.ci-providers }}_{{ '${{ matrix.rtd }}' }} --cov-report=xml --color=yes built_cookie_{{ '${{ matrix.license }}' }}_2_${{ env.ci-providers }}_{{ '${{ matrix.rtd }}' }}/tests/
+
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+
+  pip-dep:
+    needs: "generate-cookiecutter"
+    name: Test Pip (Approx) on ${{ matrix.os }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:  # Approximate strategy, uses a few other options
+      matrix:
+        os: [macOS-latest, ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.7]
+        license: 1  # Nonstandard
+        rtd: ${{ env.rtd }}  # Nonstandard
+
+    steps:
+      # - uses: actions/checkout@v1  # This isn't necessary here
+
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
+
+      - name: "Fetch Cookiecutter Builds"
+        uses: actions/download-artifact@v2
+        with:
+          name: cookiecutter_outputs
+
+      - name: "Change directory"  # Have to CD here to make sure this works
+        shell: bash
+        run: |
+          cd built_cookie_{{ '${{ matrix.license }}' }}_3_${{ env.ci-providers }}_{{ '${{ matrix.rtd }}' }}
+
+
+      - name: Install testing dependencies
+        shell: bash
+        run: |
+          python -m pip install -U pytest pytest-cov codecov
+
+      - name: Install package
+
+        shell: bash
+        run: |
+          python -m pip install .
+
+
+      - name: Run tests
+
+        shell: bash
+
+        run: |
+          pytest -v --cov=built_cookie_{ '${{ matrix.license }}' }}_3_${{ env.ci-providers }}_{{ '${{ matrix.rtd }}' }} --cov-report=xml --color=yes built_cookie_{{ '${{ matrix.license }}' }}_3_${{ env.ci-providers }}_{{ '${{ matrix.rtd }}' }}/tests/
+
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/workflows/verify-ghas.yaml
+++ b/.github/workflows/verify-ghas.yaml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   generate-cookiecutter:
-    name: "Create the Cookiecutter artifacts"
+    name: "Cookiecutter Artifacts"
     strategy:
       matrix:
         license: ${{ env.licenses }}
@@ -43,7 +43,7 @@ jobs:
         run: |
           python tests/setup_cookiecutter.py built_cookie_{{ '${{ matrix.license }}' }}_{{ '${{ matrix.depend-source }}' }}_{{ '${{ matrix.ci-provider }}' }}_{{ '${{ matrix.rtd }}' }} {{ '${{ matrix.license }}' }} {{ '${{ matrix.depend-source }}' }} {{ '${{ matrix.ci-provider }}' }} {{ '${{ matrix.rtd }}' }}
 
-      - name: "Upload outputs to artifacts"
+      - name: "Upload artifacts"
         uses: actions/upload-artifact@v2
         with:
           name: cookiecutter_outputs
@@ -62,12 +62,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: "Fetch Cookiecutter Builds"
+      - name: "Fetch Artifacts"
         uses: actions/download-artifact@v2
         with:
           name: cookiecutter_outputs
 
-      - name: "Compare CI files to reference"
+      - name: "Compare Reference CI"
         shell: bash
         run: |
           COMBO="{{ '${{ matrix.license }}' }}_{{ '${{ matrix.depend-source }}' }}_{{ '${{ matrix.ci-provider }}' }}_{{ '${{ matrix.rtd }}' }}"
@@ -93,7 +93,7 @@ jobs:
     steps:
       # - uses: actions/checkout@v1  # This isn't necessary here
 
-      - name: "Fetch Cookiecutter Builds"
+      - name: "Fetch Artifacts"
         uses: actions/download-artifact@v2
         with:
           name: cookiecutter_outputs
@@ -119,7 +119,7 @@ jobs:
           channels: conda-forge,defaults
 
           activate-environment: test
-          auto-update-conda: true
+          auto-update-conda: false
           auto-activate-base: false
           show-channel-urls: true
 
@@ -168,7 +168,7 @@ jobs:
           df -h
           ulimit -a
 
-      - name: "Fetch Cookiecutter Builds"
+      - name: "Fetch Artifacts"
         uses: actions/download-artifact@v2
         with:
           name: cookiecutter_outputs
@@ -185,7 +185,7 @@ jobs:
           environment-file: devtools/conda-envs/test_env.yaml
 
           activate-environment: test
-          auto-update-conda: true
+          auto-update-conda: false
           auto-activate-base: false
           show-channel-urls: true
 
@@ -234,7 +234,7 @@ jobs:
           df -h
           ulimit -a
 
-      - name: "Fetch Cookiecutter Builds"
+      - name: "Fetch Artifacts"
         uses: actions/download-artifact@v2
         with:
           name: cookiecutter_outputs
@@ -245,7 +245,7 @@ jobs:
           cd built_cookie_{{ '${{ matrix.license }}' }}_3_${{ env.ci-providers }}_{{ '${{ matrix.rtd }}' }}
 
 
-      - name: Install testing dependencies
+      - name: Testing Dependencies
         shell: bash
         run: |
           python -m pip install -U pytest pytest-cov codecov

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ ENV/
 # profraw files from LLVM? Unclear exactly what triggers this
 # There are reports this comes from LLVM profiling, but also Xcode 9.
 *profraw
+
+# Cookiecutter-CMS Test Artifacts
+/tests/CI_files

--- a/README.md
+++ b/README.md
@@ -135,9 +135,27 @@ links below. We do not implement them for this Cookiecutter, but they can be add
 
 ### Continuous Integration (GitHub Actions)
 
-_Note: Support for GitHub Actions is still experimental and not yet documented_.
+As of version 1.3, we provide preconfigured workflows for [GitHub Actions](https://github.com/features/actions), with 
+support for Linux, MacOS and Windows. Conda support is possible thanks to the excellent 
+[@conda-incubator's `setup-miniconda` action](https://github.com/conda-incubator/setup-miniconda). We encourage you 
+read its documentation for further details on GitHub Actions themselves.
 
-As of version 1.3, we provide preconfigured workflows for [GitHub Actions](https://github.com/features/actions), with support for Linux, MacOS and Windows. Conda support is possible thanks to the excellent [@conda-incubator's `setup-miniconda` action](https://github.com/conda-incubator/setup-miniconda). We encourage you read its documentation for further details.
+The Cookiecutter's GitHub Actions does a number of things differently than the output Actions. We detail those 
+differences below, but none of this is needed to understand the output GitHub Action Workflows, which are much simpler.
+
+The Cookiecutter ability to test GitHub Actions it generates has some limitations, but are still properly tested.
+This repository has a multi-job GitHub Action Workflow to do a few things:
+* Run the Cookiecutter and generate outputs.
+* Compare the output CI's to references.
+* Run an approximate implementation of the generated CI files.
+
+If the reference files need re-generated, there is a script to help with this.
+
+Ideally, the Cookiecutter would run the generated output files in real time. However, that is currently impossible with 
+GitHub Actions (as of October 14 2020). We Cookiecutter-CMS maintainers have also looked at reactive PR’s which 
+implement on different branches and make new PR’s and setting up dummy repositories and pushing to those and then 
+monitoring the test/return from that. This was all determined to be overly complicated, although we welcome suggestions 
+and ideas for improvements.
 
 ### Documentation
 Make a [ReadTheDocs](https://readthedocs.org) account and turn on the git hook. Although you can manually make the

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -24,5 +24,5 @@
     ],
     
     "include_ReadTheDocs": ["y", "n"],
-    "_cms_cc_version": 1.3
+    "_cms_cc_version": 1.4
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -20,7 +20,7 @@
     "continuous_integration_provider": [
         "Travis",
         "Travis+AppVeyor",
-        "GitHub Actions (experimental)"
+        "GitHub Actions"
     ],
     
     "include_ReadTheDocs": ["y", "n"],

--- a/tests/regenerate_references.sh
+++ b/tests/regenerate_references.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Regenerate the reference workflow scripts, accepts a path to the
+
+for LIC in 1 2
+do
+  for DEP in 1 2 3
+  do
+    for RTD in 1 2
+    do
+        SEQUENCE=_"$LIC"_"$DEP"_3_"$RTD"
+        python setup_cookiecutter.py prj${SEQUENCE} ${LIC} ${DEP} 3 ${RTD} ..
+        mkdir -p CI_files
+        mv prj${SEQUENCE}/.github/workflows/CI.yaml CI_files/CI${SEQUENCE}.yaml
+        rm -rf prj${SEQUENCE}
+    done
+  done
+done

--- a/tests/setup_cookiecutter.py
+++ b/tests/setup_cookiecutter.py
@@ -3,6 +3,7 @@ Simulates a cookiecutter run
 """
 
 from subprocess import Popen, PIPE, STDOUT
+from os.path import abspath
 import sys
 
 project = sys.argv[1]
@@ -10,22 +11,27 @@ lic = sys.argv[2]
 depend = sys.argv[3]
 provider = sys.argv[4]
 rtd = sys.argv[5]
-print("Options: open_source_license=%s, dependency_source=%s, ci_provider=%s" % (lic, depend, provider))
+try:
+    cookie_path = abspath(sys.argv[6])
+except IndexError:
+    cookie_path = "."
+
+print("Options: open_source_license=%s, dependency_source=%s, ci_provider=%s, rtd=%s" % (lic, depend, provider, rtd))
 
 # Setup the options
-options = [project, # Repo name
-           project, # Project name
-           project, # First module name
-           "cookie monster", # Author name
-           "cookiemonster@trash.can", # Author email
-           "", # Description
-           lic, # License
-           depend, # Dependency
-           provider, # ci_provider
+options = [project,  # Repo name
+           project,  # Project name
+           project,  # First module name
+           "cookie monster",  # Author name
+           "cookiemonster@trash.can",  # Author email
+           "",  # Description
+           lic,  # License
+           depend,  # Dependency
+           provider,  # ci_provider
            rtd] 
 
 # Open a thread
-p = Popen(["cookiecutter", "."], stdin=PIPE, stdout=PIPE)
+p = Popen(["cookiecutter", cookie_path], stdin=PIPE, stdout=PIPE)
 
 # Communicate options
 opts = "\n".join(options).encode("UTF-8")

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -33,7 +33,7 @@ jobs:
         ulimit -a
 
 {% if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
-    - name: Install testing dependencies
+    - name: Testing Dependencies
       shell: bash
       run: |
         python -m pip install -U pytest pytest-cov codecov
@@ -47,7 +47,7 @@ jobs:
         channels: conda-forge,defaults
 {% endif %}
         activate-environment: test
-        auto-update-conda: true
+        auto-update-conda: false
         auto-activate-base: false
         show-channel-urls: true
 {% endif %}


### PR DESCRIPTION
This is an experimental implementation of GitHub Actions (GHA) tests.
Because we can't dry-run or construct partials on the fly for GHAs,
the route I have chosen is to have references of the current outputs
you can get from the different cookiecutter options, and have an
implementation of those outputs in the top level GHA itself.
The logic is as follows:

* Have top level GHA replicate the generated "on" block.
* Have the top level GHA generate all of the cookiecutter options which
  use GHA as a CI source. Upload all of those builds to an artifact cache.
* One job pulls the artifacts and compares the CI.yaml file outputs
  to the references, raises an error if they differ (not blocking, but
  indicates we need to change something)
  * A helper script has been included to regenerate the references.
* 3 more jobs implement the theoretical output of the cookiecutter based
  on dependency source options. This is a manual implementation but
  should do everything the live generated CI file will do. In combination
  with the reference file check from before, this should be a sufficient
  test to see if we need to make changes.

Overall, this introduces a lag-time in updating the GHA top level tests,
but I think this does successfully allow moving GHA from experimental
to live if it works.

I'll actually be surprised if my big GHA workflow for the top level works in one go, but we can open the discussion now and talk about it while I work through bugs.

@janash , @jaimergp , @dgasmith thoughts?