### PR TITLE
[DNM] Start the migration to Python 3.9

### DIFF
--- a/.github/reference-workflows/CI_1_1_3_1.yaml
+++ b/.github/reference-workflows/CI_1_1_3_1.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_1_1_3_2.yaml
+++ b/.github/reference-workflows/CI_1_1_3_2.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_1_2_3_1.yaml
+++ b/.github/reference-workflows/CI_1_2_3_1.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_1_2_3_2.yaml
+++ b/.github/reference-workflows/CI_1_2_3_2.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_1_3_3_1.yaml
+++ b/.github/reference-workflows/CI_1_3_3_1.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_1_3_3_2.yaml
+++ b/.github/reference-workflows/CI_1_3_3_2.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_2_1_3_1.yaml
+++ b/.github/reference-workflows/CI_2_1_3_1.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_2_1_3_2.yaml
+++ b/.github/reference-workflows/CI_2_1_3_2.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_2_2_3_1.yaml
+++ b/.github/reference-workflows/CI_2_2_3_1.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_2_2_3_2.yaml
+++ b/.github/reference-workflows/CI_2_2_3_2.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_2_3_3_1.yaml
+++ b/.github/reference-workflows/CI_2_3_3_1.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/reference-workflows/CI_2_3_3_2.yaml
+++ b/.github/reference-workflows/CI_2_3_3_2.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/verify-ghas.yaml
+++ b/.github/workflows/verify-ghas.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
     steps:
       - uses: actions/checkout@v1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
       env:
         - LICENSE=1
         - DEPEND_SOURCE=1
-        - PYTHON_VER=3.7
+        - PYTHON_VER=3.9
         - CI_PROVIDER=2  # Travis+Appveyor
         - RTD=2
     - os: osx
@@ -17,7 +17,7 @@ matrix:
       env:
         - LICENSE=1
         - DEPEND_SOURCE=2
-        - PYTHON_VER=3.7
+        - PYTHON_VER=3.9
         - CI_PROVIDER=2
         - RTD=1
     - os: osx
@@ -25,7 +25,7 @@ matrix:
       env:
         - LICENSE=2
         - DEPEND_SOURCE=3
-        - PYTHON_VER=3.7
+        - PYTHON_VER=3.9
         - CI_PROVIDER=2
         - RTD=1
     - os: osx
@@ -33,7 +33,7 @@ matrix:
       env:
         - LICENSE=2
         - DEPEND_SOURCE=3
-        - PYTHON_VER=3.7
+        - PYTHON_VER=3.9
         - CI_PROVIDER=1  # Travis only
         - RTD=1
     - os: osx
@@ -41,7 +41,7 @@ matrix:
       env:
         - LICENSE=1
         - DEPEND_SOURCE=1
-        - PYTHON_VER=3.6
+        - PYTHON_VER=3.7
         - CI_PROVIDER=2
         - RTD=1
     - os: osx
@@ -49,7 +49,7 @@ matrix:
       env:
         - LICENSE=1
         - DEPEND_SOURCE=2
-        - PYTHON_VER=3.6
+        - PYTHON_VER=3.7
         - CI_PROVIDER=2
         - RTD=1
     - os: osx
@@ -57,52 +57,11 @@ matrix:
       env:
         - LICENSE=2
         - DEPEND_SOURCE=3
-        - PYTHON_VER=3.6
+        - PYTHON_VER=3.7
         - CI_PROVIDER=2
         - RTD=1
     - os: osx
       language: generic
-      env:
-        - LICENSE=2
-        - DEPEND_SOURCE=3
-        - PYTHON_VER=3.6
-        - CI_PROVIDER=1
-        - RTD=1
-
-    # Pin Xenial for 3.7
-    - os: linux
-      dist: xenial
-      python: 3.7
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=1
-        - PYTHON_VER=3.7
-        - CI_PROVIDER=2
-        - RTD=1
-
-    - os: linux
-      dist: xenial
-      python: 3.7
-      env:
-        - LICENSE=1
-        - DEPEND_SOURCE=2
-        - PYTHON_VER=3.7
-        - CI_PROVIDER=2
-        - RTD=1
-
-    - os: linux
-      dist: xenial
-      python: 3.7
-      env:
-        - LICENSE=2
-        - DEPEND_SOURCE=3
-        - PYTHON_VER=3.7
-        - CI_PROVIDER=2
-        - RTD=1
-
-    - os: linux
-      dist: xenial
-      python: 3.7
       env:
         - LICENSE=2
         - DEPEND_SOURCE=3
@@ -111,38 +70,74 @@ matrix:
         - RTD=1
 
     - os: linux
-      python: 3.6
+      python: 3.9-dev
       env:
         - LICENSE=1
         - DEPEND_SOURCE=1
-        - PYTHON_VER=3.6
+        - PYTHON_VER=3.9
         - CI_PROVIDER=2
         - RTD=1
 
     - os: linux
-      python: 3.6
+      python: 3.9-dev
       env:
         - LICENSE=1
         - DEPEND_SOURCE=2
-        - PYTHON_VER=3.6
+        - PYTHON_VER=3.9
         - CI_PROVIDER=2
         - RTD=1
 
     - os: linux
-      python: 3.6
+      python: 3.9-dev
       env:
         - LICENSE=2
         - DEPEND_SOURCE=3
-        - PYTHON_VER=3.6
+        - PYTHON_VER=3.9
         - CI_PROVIDER=2
         - RTD=1
 
     - os: linux
-      python: 3.6
+      python: 3.9
       env:
         - LICENSE=2
         - DEPEND_SOURCE=3
-        - PYTHON_VER=3.6
+        - PYTHON_VER=3.9
+        - CI_PROVIDER=1
+        - RTD=1
+
+    - os: linux
+      python: 3.8
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=1
+        - PYTHON_VER=3.8
+        - CI_PROVIDER=2
+        - RTD=1
+
+    - os: linux
+      python: 3.8
+      env:
+        - LICENSE=1
+        - DEPEND_SOURCE=2
+        - PYTHON_VER=3.8
+        - CI_PROVIDER=2
+        - RTD=1
+
+    - os: linux
+      python: 3.8
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.8
+        - CI_PROVIDER=2
+        - RTD=1
+
+    - os: linux
+      python: 3.8
+      env:
+        - LICENSE=2
+        - DEPEND_SOURCE=3
+        - PYTHON_VER=3.8
         - CI_PROVIDER=1
         - RTD=1
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ remove deployment platforms, or test with a different suite.
 
 ## Requirements
 
-* Python 3.6, or 3.7
+* Python 3.8, or 3.9
 * [Cookiecutter](http://cookiecutter.readthedocs.io/en/latest/installation.html)
 * [Git](https://git-scm.com/)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,26 +1,26 @@
 environment:
 
   matrix:
-    - PYTHON: "C:\\Miniconda36-x64"
+    - PYTHON: "C:\\Miniconda37-x64"
       LICENSE: 1
       DEPEND_SOURCE: 1
-      PYTHON_VERSION: "3.6"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       CI_PROVIDER: 2  # Travis+Appveyor
       RTD: 1
 
-    - PYTHON: "C:\\Miniconda37-x64"
+    - PYTHON: "C:\\Miniconda38-x64"
       LICENSE: 2
       DEPEND_SOURCE: 2
-      PYTHON_VERSION: "3.7"
+      PYTHON_VERSION: "3.8"
       PYTHON_ARCH: "64"
       CI_PROVIDER: 2
       RTD: 2
 
-    - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
       LICENSE: 1
       DEPEND_SOURCE: 3
-      PYTHON_VERSION: "3.6"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       CI_PROVIDER: 2
       RTD: 2

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -7,25 +7,24 @@ matrix:
     # Extra includes for OSX since python language is not available by default on OSX
     - os: osx
       language: generic
-      env: PYTHON_VER=3.6
+      env: PYTHON_VER=3.8
     - os: osx
       language: generic
-      env: PYTHON_VER=3.7
+      env: PYTHON_VER=3.9
 
 {% if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
     # Pip can use Travis build-in Python
     - os: linux
-      python: 3.6
+      python: 3.8
     - os: linux
-      dist: xenial  # Travis Trusty image does not have Python 3.7, Xenial does
-      python: 3.7
+      python: 3.9-dev
 {% else %}
     - os: linux
       language: generic  # No need to set Python version since its conda
-      env: PYTHON_VER=3.6
+      env: PYTHON_VER=3.8
     - os: linux
       language: generic
-      env: PYTHON_VER=3.7
+      env: PYTHON_VER=3.9
 {% endif %}
 
 before_install:

--- a/{{cookiecutter.repo_name}}/appveyor.yml
+++ b/{{cookiecutter.repo_name}}/appveyor.yml
@@ -2,21 +2,21 @@ environment:
 
   matrix:
   {%- if (cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' or cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback') %}
-    - PYTHON: "C:\\Miniconda36-x64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Miniconda37-x64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
-  {% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "64"
 
+  - PYTHON: "C:\\Miniconda38-x64"
+    PYTHON_VERSION: "3.8"
+    PYTHON_ARCH: "64"
+  {% elif cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
+
+  - PYTHON: "C:\\Python38-x64"
+    PYTHON_VERSION: "3.8"
+    PYTHON_ARCH: "64"
   {% endif %}
 
 install:


### PR DESCRIPTION
This commit and PR starts testing against Python 3.9 in the CI builds.

The CI vendors have not all caught up yet though.
* Travis only has Python 3.9-dev
* Appveyor has no Python 3.9 miniconda or otherwise.

They are working on it though and we should revisit this PR over the
next week or so to check if they've implemented it.