### PR TITLE
Allow GitHub Actions to run on both "master" and "main"

### DIFF
--- a/.github/reference-workflows/CI_1_1_3_1.yaml
+++ b/.github/reference-workflows/CI_1_1_3_1.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_1_1_3_2.yaml
+++ b/.github/reference-workflows/CI_1_1_3_2.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_1_2_3_1.yaml
+++ b/.github/reference-workflows/CI_1_2_3_1.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_1_2_3_2.yaml
+++ b/.github/reference-workflows/CI_1_2_3_2.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_1_3_3_1.yaml
+++ b/.github/reference-workflows/CI_1_3_3_1.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_1_3_3_2.yaml
+++ b/.github/reference-workflows/CI_1_3_3_2.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_2_1_3_1.yaml
+++ b/.github/reference-workflows/CI_2_1_3_1.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_2_1_3_2.yaml
+++ b/.github/reference-workflows/CI_2_1_3_2.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_2_2_3_1.yaml
+++ b/.github/reference-workflows/CI_2_2_3_1.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_2_2_3_2.yaml
+++ b/.github/reference-workflows/CI_2_2_3_2.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_2_3_3_1.yaml
+++ b/.github/reference-workflows/CI_2_3_3_1.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/reference-workflows/CI_2_3_3_2.yaml
+++ b/.github/reference-workflows/CI_2_3_3_2.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/.github/workflows/verify-ghas.yaml
+++ b/.github/workflows/verify-ghas.yaml
@@ -2,12 +2,17 @@ name: Pseudo Validate GHA Output
 
 # Approximation of the GHA "on" block
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -1,12 +1,17 @@
 name: CI
 
 on:
+  # GitHub has started calling new repo's first branch "main" https://github.com/github/renaming
+  # Existing codes likely still have "master" as the primary branch
+  # Both are tracked here to keep legacy and new codes working
   push:
     branches:
       - "master"
+      - "main"
   pull_request:
     branches:
       - "master"
+      - "main"
   schedule:
     # Nightly tests run on master by default:
     #   Scheduled workflows run on the latest commit on the default or base branch.


### PR DESCRIPTION
New GitHub Repositories have their first branch called "main" now
instead of "master." Details [here](https://github.com/github/renaming).

Because some people might start with a blank repository from GitHub,
and some people may start from `git init`, i've added support for
both in GitHub Actions to handle both start points.

There is a corner case if someone creates the repo on GitHub, uses the
cookiecutter (which `git init`), then the default branch names might
clash. But until we start to see this conflict be an issue, I don't
think there is extra engineering which needs to be done at this moment.

Fixes #120