### PR TITLE
Update `setup-miniconda` to v2

### DIFF
--- a/.github/reference-workflows/CI_1_1_3_1.yaml
+++ b/.github/reference-workflows/CI_1_1_3_1.yaml
@@ -39,7 +39,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/reference-workflows/CI_1_1_3_2.yaml
+++ b/.github/reference-workflows/CI_1_1_3_2.yaml
@@ -39,7 +39,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/reference-workflows/CI_1_2_3_1.yaml
+++ b/.github/reference-workflows/CI_1_2_3_1.yaml
@@ -39,7 +39,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/reference-workflows/CI_1_2_3_2.yaml
+++ b/.github/reference-workflows/CI_1_2_3_2.yaml
@@ -39,7 +39,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/reference-workflows/CI_2_1_3_1.yaml
+++ b/.github/reference-workflows/CI_2_1_3_1.yaml
@@ -39,7 +39,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/reference-workflows/CI_2_1_3_2.yaml
+++ b/.github/reference-workflows/CI_2_1_3_2.yaml
@@ -39,7 +39,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/reference-workflows/CI_2_2_3_1.yaml
+++ b/.github/reference-workflows/CI_2_2_3_1.yaml
@@ -39,7 +39,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/reference-workflows/CI_2_2_3_2.yaml
+++ b/.github/reference-workflows/CI_2_2_3_2.yaml
@@ -39,7 +39,7 @@ jobs:
 
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/test_env.yaml

--- a/.github/workflows/verify-ghas.yaml
+++ b/.github/workflows/verify-ghas.yaml
@@ -137,7 +137,7 @@ jobs:
 #          cd prj_${{ matrix.license }}_1_${{ env.ci-providers }}_${{ matrix.rtd }}
 
       # More info on options: https://github.com/conda-incubator/setup-miniconda
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: prj_${{ matrix.license }}_1_${{ env.ci-providers }}_${{ matrix.rtd }}/devtools/conda-envs/test_env.yaml
@@ -207,7 +207,7 @@ jobs:
 #          cd prj_${{ matrix.license }}_2_${{ env.ci-providers }}_${{ matrix.rtd }}
 
       # More info on options: https://github.com/conda-incubator/setup-miniconda
-      - uses: conda-incubator/setup-miniconda@v1
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: prj_${{ matrix.license }}_2_${{ env.ci-providers }}_${{ matrix.rtd }}/devtools/conda-envs/test_env.yaml

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -49,7 +49,7 @@ jobs:
         python -m pip install -U pytest pytest-cov codecov
 {% else %}
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v1
+    - uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: {{ '${{ matrix.python-version }}' }}
         environment-file: devtools/conda-envs/test_env.yaml


### PR DESCRIPTION
`add-path` and `set-env` commands are deprecated and will be disabled on November 16th. More information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/