### PR TITLE
Explicitly provide a separate short_description.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,6 +4,7 @@
     "first_module_name": "{{ cookiecutter.repo_name.lower().replace(' ', '_') }}",
     "author_name": "Your name (or your organization/company/team)",
     "author_email": "Your email (or your organization/company/team)",
+    "short_description": "A one-line terse project description.",
     "description": "A short description of the project.",
     "open_source_license": [
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
@@ -1,5 +1,6 @@
 """
-{{cookiecutter.project_name}}
+{{cookiecutter.short_description}}
+
 {{cookiecutter.description}}
 """
 


### PR DESCRIPTION
Resolve an awkward bit of boiler plate discussed at #130.

Standard Python package metadata includes a short description and a long description. We can make the cookiecutter more explicit in this regard. Then we would have content that can be directly placed in `__init__.py` for a PEP-257-compliant docstring.

I recognize that changing the cookiecutter parameters may not be something to undertake lightly, so I did not include this change in #131.