### PR TITLE
Explicitly use cookiecutter.description as short_description.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,5 +19,5 @@
     ],
     
     "include_ReadTheDocs": ["y", "n"],
-  "_cms_cc_version": 1.5
+  "_cms_cc_version": 1.6
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,7 +4,7 @@
     "first_module_name": "{{ cookiecutter.repo_name.lower().replace(' ', '_') }}",
     "author_name": "Your name (or your organization/company/team)",
     "author_email": "Your email (or your organization/company/team)",
-    "description": "A short description of the project.",
+    "description": "A short description of the project (less than one line).",
     "open_source_license": [
 
         "MIT",

--- a/{{cookiecutter.repo_name}}/setup.py
+++ b/{{cookiecutter.repo_name}}/setup.py
@@ -6,7 +6,7 @@ import sys
 from setuptools import setup, find_packages
 import versioneer
 
-short_description = __doc__.split("\n")
+short_description = "{{cookiecutter.description}}".split("\n")[0]
 
 # from https://github.com/pytest-dev/pytest-runner#conditional-requirement
 needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
@@ -16,7 +16,7 @@ try:
     with open("README.md", "r") as handle:
         long_description = handle.read()
 except:
-    long_description = "\n".join(short_description[2:])
+    long_description = None
 
 
 setup(
@@ -24,7 +24,7 @@ setup(
     name='{{cookiecutter.repo_name}}',
     author='{{cookiecutter.author_name}}',
     author_email='{{cookiecutter.author_email}}',
-    description=short_description[0],
+    description=short_description,
     long_description=long_description,
     long_description_content_type="text/markdown",
     version=versioneer.get_version(),

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
@@ -1,8 +1,4 @@
-"""
-short description of {{cookiecutter.project_name}}.
-
-{{cookiecutter.description}}
-"""
+"""{{cookiecutter.description}}"""
 
 # Add imports here
 from .{{cookiecutter.first_module_name}} import *


### PR DESCRIPTION
Supersedes PR #132 

* Advise users on brevity.
* Assume (but check) for one-line short description
  for Python package metadata.
* Use short description for package docstring.

The long description was already derived from the README file
for the package metadata, so PR #132 was conceptually divergent.

On review of issue #130, the consensus was that it would be annoying
to require users to enter a long description during `cookiecutter`
execution and that we shouldn't assume users will (or will want to)
update a stub in their `__init__.py` docstring. Instead, this change
generates a PEP-257 compliant docstring for the package, which the user
can edit or extend at their option at some point after the initial
project generation.