### PR TITLE
Fix import sorting in test file

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.repo_name}}.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.repo_name}}.py
@@ -3,9 +3,11 @@ Unit and regression test for the {{cookiecutter.repo_name}} package.
 """
 
 # Import package, test suite, and other packages as needed
-import {{cookiecutter.repo_name}}
-import pytest
 import sys
+
+import pytest
+import {{cookiecutter.repo_name}}
+
 
 def test_{{cookiecutter.repo_name}}_imported():
     """Sample test, will always pass so long as import statement worked."""

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.repo_name}}.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/tests/test_{{cookiecutter.repo_name}}.py
@@ -6,6 +6,7 @@ Unit and regression test for the {{cookiecutter.repo_name}} package.
 import sys
 
 import pytest
+
 import {{cookiecutter.repo_name}}
 
 


### PR DESCRIPTION
The imports need to be sorted in order to follow [PEP 8 style](https://www.python.org/dev/peps/pep-0008/#imports). I also confirm this change with [isort](https://github.com/PyCQA/isort).