### PR TITLE
PEP 621

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -1,6 +1,62 @@
 [build-system]
-requires = ["setuptools>=42.0", "wheel", "versioningit~=2.0"]
+requires = ["setuptools>=61.0", "wheel", "versioningit~=2.0"]
 build-backend = "setuptools.build_meta"
+
+# Self-descriptive entries which should always be present
+# https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+[project]
+name = "{{cookiecutter.repo_name}}"
+description = "{{cookiecutter.description}}"
+dynamic = ["version"]
+readme = "README.md"
+authors = [
+    { name = "{{cookiecutter.author_name}}", email = "{{cookiecutter.author_email}}" }
+]
+license = { text = "{{cookiecutter.open_source_license}}" }
+# See https://pypi.org/classifiers/
+classifiers = [{% if cookiecutter.open_source_license == 'MIT' %}
+    "License :: OSI Approved :: MIT License",{% elif cookiecutter.open_source_license == 'BSD-3-Clause' %}
+    "License :: OSI Approved :: BSD License",{% elif cookiecutter.open_source_license == 'LGPLv3' %}
+    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",{% endif %}
+    "Programming Language :: Python :: 3",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "importlib-resources; python_version<'3.10'",
+]
+
+# Update the urls once the hosting is set up.
+#[project.urls]
+#"Source" = "https://github.com/<username>/{{cookiecutter.repo_name}}"
+#"Documentation" = "https://{{cookiecutter.repo_name}}.readthedocs.io/"
+
+[project.optional-dependencies]
+test = [
+  "pytest>=6.1.2",
+  "pytest-runner"
+]
+
+# Let setuptools discover the package in the current directory,
+# but be explicit about non-Python files.
+# See also:
+#   https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration
+# Note that behavior is currently evolving with respect to how to interpret the
+# "data" and "tests" subdirectories. As of setuptools 63, both are automatically
+# included if namespaces is true (default), even if the package is named explicitly
+# (instead of using 'find'). With 'find', the 'tests' subpackage is discovered
+# recursively because of its __init__.py file, but the data subdirectory is excluded
+# with include-package-data = false and namespaces = false.
+[tool.setuptools]
+include-package-data = false
+[tool.setuptools.packages.find]
+namespaces = false
+where = ["."]
+
+# Ref https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data
+[tool.setuptools.package-data]
+{{cookiecutter.repo_name}} = [
+    "py.typed"
+]
 
 [tool.versioningit]
 default-version = "1+unknown"

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "versioningit~=2.0"]
+requires = ["setuptools>=61.0", "versioningit~=2.0"]
 build-backend = "setuptools.build_meta"
 
 # Self-descriptive entries which should always be present
@@ -21,13 +21,14 @@ classifiers = [{% if cookiecutter.open_source_license == 'MIT' %}
     "Programming Language :: Python :: 3",
 ]
 requires-python = ">=3.8"
-dependencies = [
-    "importlib-resources; python_version<'3.10'",
-]
+# Declare any run-time dependencies that should be installed with the package.
+#dependencies = [
+#    "importlib-resources;python_version<'3.10'",
+#]
 
 # Update the urls once the hosting is set up.
 #[project.urls]
-#"Source" = "https://github.com/<username>/{{cookiecutter.repo_name}}"
+#"Source" = "https://github.com/<username>/{{cookiecutter.repo_name}}/"
 #"Documentation" = "https://{{cookiecutter.repo_name}}.readthedocs.io/"
 
 [project.optional-dependencies]
@@ -36,6 +37,14 @@ test = [
   "pytest-runner"
 ]
 
+[tool.setuptools]
+# As of version 0.971, mypy does not support type checking of installed zipped
+# packages (because it does not actually import the Python packages).
+# We declare the package not-zip-safe so that our type hints are also available
+# when checking client code that uses our (installed) package.
+# Ref:
+# https://mypy.readthedocs.io/en/stable/installed_packages.html?highlight=zip#using-installed-packages-with-mypy-pep-561
+zip_safe = false
 # Let setuptools discover the package in the current directory,
 # but be explicit about non-Python files.
 # See also:
@@ -46,7 +55,6 @@ test = [
 # (instead of using 'find'). With 'find', the 'tests' subpackage is discovered
 # recursively because of its __init__.py file, but the data subdirectory is excluded
 # with include-package-data = false and namespaces = false.
-[tool.setuptools]
 include-package-data = false
 [tool.setuptools.packages.find]
 namespaces = false

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -38,13 +38,15 @@ test = [
 ]
 
 [tool.setuptools]
+# This subkey is a beta stage development and keys may change in the future, see https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html for more details
+#
 # As of version 0.971, mypy does not support type checking of installed zipped
 # packages (because it does not actually import the Python packages).
 # We declare the package not-zip-safe so that our type hints are also available
 # when checking client code that uses our (installed) package.
 # Ref:
 # https://mypy.readthedocs.io/en/stable/installed_packages.html?highlight=zip#using-installed-packages-with-mypy-pep-561
-zip_safe = false
+zip-safe = false
 # Let setuptools discover the package in the current directory,
 # but be explicit about non-Python files.
 # See also:

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -1,59 +1,5 @@
 # Helper file to handle all configs
 
-# setuptools configuration.
-# see https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
-[metadata]
-# Self-descriptive entries which should always be present
-name = {{cookiecutter.repo_name}}
-author = {{cookiecutter.author_name}}
-author_email = {{cookiecutter.author_email}}
-description = {{cookiecutter.description}}
-long_description = file: README.md
-long_description_content_type = "text/markdown"
-version = attr: {{cookiecutter.repo_name}}.__version__
-license = {{cookiecutter.open_source_license}}
-python_requires = ">=3.7"
-# See https://pypi.org/classifiers/
-classifiers ={% if cookiecutter.open_source_license == 'MIT' %}
-    License :: OSI Approved :: MIT License{% elif cookiecutter.open_source_license == 'BSD-3-Clause' %}
-    License :: OSI Approved :: BSD License{% elif cookiecutter.open_source_license == 'LGPLv3' %}
-    License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+){% endif %}
-    Programming Language :: Python :: 3
-# Update the urls and uncomment, once the hosting is set up.
-#project_urls =
-#    Source = https://github.com/<username>/{{cookiecutter.repo_name}}/
-#    Documentation = https://{{cookiecutter.repo_name}}.readthedocs.io/
-# Other possible metadata.
-# Ref https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
-#keywords = one, two
-#platforms = ["Linux",
-#             "Mac OS-X",
-#             "Unix",
-#             "Windows"]
-
-[options]
-# Manual control if final package is compressible or not, set False to prevent the .egg from being made
-zip_safe = True
-install_requires =
-    importlib-resources; python_version<"3.10"
-tests_require =
-    pytest>=6.1.2
-    pytest-runner
-# Which Python importable modules should be included when your package is installed
-# Handled automatically by setuptools. Use 'exclude' to prevent some specific
-# subpackage(s) from being added, if needed
-packages = find:
-# Alternatively, see ; https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#using-a-src-layout
-#package_dir =
-#    =src
-[options.packages.find]
-where = .
-
-# Optionally, include package data to ship with your package
-# Customize MANIFEST.in if the general case does not suit your needs
-[options.package_data]
-{{cookiecutter.repo_name}} = py.typed
-
 [coverage:run]
 # .coveragerc to control coverage.py and pytest-cov
 omit =

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/data/README.md
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/data/README.md
@@ -17,6 +17,20 @@ Update the [tool.setuptools.package_data](https://setuptools.pypa.io/en/latest/u
 and point it at the correct files.
 Paths are relative to `package_dir`.
 
+Package data can be accessed at run time with `importlib.resources` or the `importlib_resources` back port.
+See https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime
+for suggestions.
+
+If modules within your package will access internal data files using
+[the recommended approach](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#accessing-data-files-at-runtime),
+you may need to include `importlib_resources` in your package dependencies.
+In `pyproject.toml`, include the following in your `[project]` table.
+```
+dependencies = [
+    "importlib-resources;python_version<'3.10'",
+]
+```
+
 ## Manifest
 
 * `look_and_say.dat`: first entries of the "Look and Say" integer series, sequence [A005150](https://oeis.org/A005150)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/data/README.md
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/data/README.md
@@ -12,8 +12,8 @@ cap.
 
 ## Including package data
 
-Modify your package's `setup.cfg` file.
-Update the [options.package_data](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#options)
+Modify your package's `pyproject.toml` file.
+Update the [tool.setuptools.package_data](https://setuptools.pypa.io/en/latest/userguide/datafiles.html#package-data)
 and point it at the correct files.
 Paths are relative to `package_dir`.
 


### PR DESCRIPTION
Move the metadata and as much setuptools configuration as possible
to pyproject.toml.

This reduces reliance on setup.cfg, and maximally generalizes
the build system configuration as supported by setuptools 61.0.

TODO:
* update cookiecutter version
* update documentation

Per discussion at #149, it seems appropriate to wait at least a few months before finalizing and considering this PR.