### PR TITLE
Remove out-of-date versioneer import

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/__init__.py
@@ -2,6 +2,3 @@
 
 # Add imports here
 from .{{cookiecutter.first_module_name}} import *
-
-
-from ._version import __version__


### PR DESCRIPTION
Hi!

I might just be thick, but I'm getting `ModuleNotFoundError: No module named 'projectname._version'` when loading a new project in a Python interpreter or Sphinx. I think this line is just left over from the versioneer -> versioningit transition, but I'm surprised no one has reported it in nearly a month!