### PR TITLE
Switch to micromamba

### DIFF
--- a/.github/reference-workflows/CI_1_1_1.yaml
+++ b/.github/reference-workflows/CI_1_1_1.yaml
@@ -27,41 +27,32 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: devtools/conda-envs/test_env.yaml
+          environment-name: test
+          channels: conda-forge,defaults
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: conda-forge,defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
-
-    - name: Install package
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
+      - name: Install package
+        # conda setup requires this special shell
+        shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        conda list
-
+        micromamba list
 
     - name: Run tests
-
       # conda setup requires this special shell
       shell: bash -l {0}
-
       run: |
         pytest -v --cov=prj_1_1_1 --cov-report=xml --color=yes prj_1_1_1/tests/
 

--- a/.github/reference-workflows/CI_1_1_1.yaml
+++ b/.github/reference-workflows/CI_1_1_1.yaml
@@ -46,19 +46,19 @@ jobs:
       - name: Install package
         # conda setup requires this special shell
         shell: bash -l {0}
-      run: |
-        python -m pip install . --no-deps
-        micromamba list
+        run: |
+          python -m pip install . --no-deps
+          micromamba list
 
-    - name: Run tests
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        pytest -v --cov=prj_1_1_1 --cov-report=xml --color=yes prj_1_1_1/tests/
+      - name: Run tests
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=prj_1_1_1 --cov-report=xml --color=yes prj_1_1_1/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_1_2.yaml
+++ b/.github/reference-workflows/CI_1_1_2.yaml
@@ -46,19 +46,19 @@ jobs:
       - name: Install package
         # conda setup requires this special shell
         shell: bash -l {0}
-      run: |
-        python -m pip install . --no-deps
-        micromamba list
+        run: |
+          python -m pip install . --no-deps
+          micromamba list
 
-    - name: Run tests
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        pytest -v --cov=prj_1_1_2 --cov-report=xml --color=yes prj_1_1_2/tests/
+      - name: Run tests
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=prj_1_1_2 --cov-report=xml --color=yes prj_1_1_2/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_1_2.yaml
+++ b/.github/reference-workflows/CI_1_1_2.yaml
@@ -27,41 +27,32 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: devtools/conda-envs/test_env.yaml
+          environment-name: test
+          channels: conda-forge,defaults
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: conda-forge,defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
-
-    - name: Install package
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
+      - name: Install package
+        # conda setup requires this special shell
+        shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        conda list
-
+        micromamba list
 
     - name: Run tests
-
       # conda setup requires this special shell
       shell: bash -l {0}
-
       run: |
         pytest -v --cov=prj_1_1_2 --cov-report=xml --color=yes prj_1_1_2/tests/
 

--- a/.github/reference-workflows/CI_1_2_1.yaml
+++ b/.github/reference-workflows/CI_1_2_1.yaml
@@ -46,19 +46,19 @@ jobs:
       - name: Install package
         # conda setup requires this special shell
         shell: bash -l {0}
-      run: |
-        python -m pip install . --no-deps
-        micromamba list
+        run: |
+          python -m pip install . --no-deps
+          micromamba list
 
-    - name: Run tests
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        pytest -v --cov=prj_1_2_1 --cov-report=xml --color=yes prj_1_2_1/tests/
+      - name: Run tests
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=prj_1_2_1 --cov-report=xml --color=yes prj_1_2_1/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_2_1.yaml
+++ b/.github/reference-workflows/CI_1_2_1.yaml
@@ -27,41 +27,32 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: devtools/conda-envs/test_env.yaml
+          environment-name: test
+          channels: defaults
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
-
-    - name: Install package
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
+      - name: Install package
+        # conda setup requires this special shell
+        shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        conda list
-
+        micromamba list
 
     - name: Run tests
-
       # conda setup requires this special shell
       shell: bash -l {0}
-
       run: |
         pytest -v --cov=prj_1_2_1 --cov-report=xml --color=yes prj_1_2_1/tests/
 

--- a/.github/reference-workflows/CI_1_2_2.yaml
+++ b/.github/reference-workflows/CI_1_2_2.yaml
@@ -27,41 +27,32 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: devtools/conda-envs/test_env.yaml
+          environment-name: test
+          channels: defaults
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
-
-    - name: Install package
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
+      - name: Install package
+        # conda setup requires this special shell
+        shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        conda list
-
+        micromamba list
 
     - name: Run tests
-
       # conda setup requires this special shell
       shell: bash -l {0}
-
       run: |
         pytest -v --cov=prj_1_2_2 --cov-report=xml --color=yes prj_1_2_2/tests/
 

--- a/.github/reference-workflows/CI_1_2_2.yaml
+++ b/.github/reference-workflows/CI_1_2_2.yaml
@@ -46,19 +46,19 @@ jobs:
       - name: Install package
         # conda setup requires this special shell
         shell: bash -l {0}
-      run: |
-        python -m pip install . --no-deps
-        micromamba list
+        run: |
+          python -m pip install . --no-deps
+          micromamba list
 
-    - name: Run tests
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        pytest -v --cov=prj_1_2_2 --cov-report=xml --color=yes prj_1_2_2/tests/
+      - name: Run tests
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=prj_1_2_2 --cov-report=xml --color=yes prj_1_2_2/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_3_1.yaml
+++ b/.github/reference-workflows/CI_1_3_1.yaml
@@ -27,37 +27,37 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Testing Dependencies
-      shell: bash
-      run: |
-        python -m pip install -U pytest pytest-cov codecov
+      - name: Testing Dependencies
+        shell: bash
+        run: |
+          python -m pip install -U pytest pytest-cov codecov
 
-    - name: Install package
-      shell: bash
-      run: |
-        python -m pip install .
+      - name: Install package
+        shell: bash
+        run: |
+          python -m pip install .
 
-    - name: Run tests
-      shell: bash
+      - name: Run tests
+        shell: bash
 
-      run: |
-        pytest -v --cov=prj_1_3_1 --cov-report=xml --color=yes prj_1_3_1/tests/
+        run: |
+          pytest -v --cov=prj_1_3_1 --cov-report=xml --color=yes prj_1_3_1/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_3_1.yaml
+++ b/.github/reference-workflows/CI_1_3_1.yaml
@@ -34,7 +34,6 @@ jobs:
         df -h
         ulimit -a
 
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -46,14 +45,11 @@ jobs:
         python -m pip install -U pytest pytest-cov codecov
 
     - name: Install package
-
       shell: bash
       run: |
         python -m pip install .
 
-
     - name: Run tests
-
       shell: bash
 
       run: |

--- a/.github/reference-workflows/CI_1_3_2.yaml
+++ b/.github/reference-workflows/CI_1_3_2.yaml
@@ -27,37 +27,37 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Testing Dependencies
-      shell: bash
-      run: |
-        python -m pip install -U pytest pytest-cov codecov
+      - name: Testing Dependencies
+        shell: bash
+        run: |
+          python -m pip install -U pytest pytest-cov codecov
 
-    - name: Install package
-      shell: bash
-      run: |
-        python -m pip install .
+      - name: Install package
+        shell: bash
+        run: |
+          python -m pip install .
 
-    - name: Run tests
-      shell: bash
+      - name: Run tests
+        shell: bash
 
-      run: |
-        pytest -v --cov=prj_1_3_2 --cov-report=xml --color=yes prj_1_3_2/tests/
+        run: |
+          pytest -v --cov=prj_1_3_2 --cov-report=xml --color=yes prj_1_3_2/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_1_3_2.yaml
+++ b/.github/reference-workflows/CI_1_3_2.yaml
@@ -34,7 +34,6 @@ jobs:
         df -h
         ulimit -a
 
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -46,14 +45,11 @@ jobs:
         python -m pip install -U pytest pytest-cov codecov
 
     - name: Install package
-
       shell: bash
       run: |
         python -m pip install .
 
-
     - name: Run tests
-
       shell: bash
 
       run: |

--- a/.github/reference-workflows/CI_2_1_1.yaml
+++ b/.github/reference-workflows/CI_2_1_1.yaml
@@ -46,19 +46,19 @@ jobs:
       - name: Install package
         # conda setup requires this special shell
         shell: bash -l {0}
-      run: |
-        python -m pip install . --no-deps
-        micromamba list
+        run: |
+          python -m pip install . --no-deps
+          micromamba list
 
-    - name: Run tests
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        pytest -v --cov=prj_2_1_1 --cov-report=xml --color=yes prj_2_1_1/tests/
+      - name: Run tests
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=prj_2_1_1 --cov-report=xml --color=yes prj_2_1_1/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_2_1_1.yaml
+++ b/.github/reference-workflows/CI_2_1_1.yaml
@@ -27,41 +27,32 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: devtools/conda-envs/test_env.yaml
+          environment-name: test
+          channels: conda-forge,defaults
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: conda-forge,defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
-
-    - name: Install package
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
+      - name: Install package
+        # conda setup requires this special shell
+        shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        conda list
-
+        micromamba list
 
     - name: Run tests
-
       # conda setup requires this special shell
       shell: bash -l {0}
-
       run: |
         pytest -v --cov=prj_2_1_1 --cov-report=xml --color=yes prj_2_1_1/tests/
 

--- a/.github/reference-workflows/CI_2_1_2.yaml
+++ b/.github/reference-workflows/CI_2_1_2.yaml
@@ -27,41 +27,32 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: devtools/conda-envs/test_env.yaml
+          environment-name: test
+          channels: conda-forge,defaults
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: conda-forge,defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
-
-    - name: Install package
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
+      - name: Install package
+        # conda setup requires this special shell
+        shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        conda list
-
+        micromamba list
 
     - name: Run tests
-
       # conda setup requires this special shell
       shell: bash -l {0}
-
       run: |
         pytest -v --cov=prj_2_1_2 --cov-report=xml --color=yes prj_2_1_2/tests/
 

--- a/.github/reference-workflows/CI_2_1_2.yaml
+++ b/.github/reference-workflows/CI_2_1_2.yaml
@@ -46,19 +46,19 @@ jobs:
       - name: Install package
         # conda setup requires this special shell
         shell: bash -l {0}
-      run: |
-        python -m pip install . --no-deps
-        micromamba list
+        run: |
+          python -m pip install . --no-deps
+          micromamba list
 
-    - name: Run tests
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        pytest -v --cov=prj_2_1_2 --cov-report=xml --color=yes prj_2_1_2/tests/
+      - name: Run tests
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=prj_2_1_2 --cov-report=xml --color=yes prj_2_1_2/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_2_2_1.yaml
+++ b/.github/reference-workflows/CI_2_2_1.yaml
@@ -46,19 +46,19 @@ jobs:
       - name: Install package
         # conda setup requires this special shell
         shell: bash -l {0}
-      run: |
-        python -m pip install . --no-deps
-        micromamba list
+        run: |
+          python -m pip install . --no-deps
+          micromamba list
 
-    - name: Run tests
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        pytest -v --cov=prj_2_2_1 --cov-report=xml --color=yes prj_2_2_1/tests/
+      - name: Run tests
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=prj_2_2_1 --cov-report=xml --color=yes prj_2_2_1/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_2_2_1.yaml
+++ b/.github/reference-workflows/CI_2_2_1.yaml
@@ -27,41 +27,32 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: devtools/conda-envs/test_env.yaml
+          environment-name: test
+          channels: defaults
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
-
-    - name: Install package
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
+      - name: Install package
+        # conda setup requires this special shell
+        shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        conda list
-
+        micromamba list
 
     - name: Run tests
-
       # conda setup requires this special shell
       shell: bash -l {0}
-
       run: |
         pytest -v --cov=prj_2_2_1 --cov-report=xml --color=yes prj_2_2_1/tests/
 

--- a/.github/reference-workflows/CI_2_2_2.yaml
+++ b/.github/reference-workflows/CI_2_2_2.yaml
@@ -27,41 +27,32 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: devtools/conda-envs/test_env.yaml
+          environment-name: test
+          channels: defaults
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/test_env.yaml
-
-        channels: defaults
-
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
-
-    - name: Install package
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
+      - name: Install package
+        # conda setup requires this special shell
+        shell: bash -l {0}
       run: |
         python -m pip install . --no-deps
-        conda list
-
+        micromamba list
 
     - name: Run tests
-
       # conda setup requires this special shell
       shell: bash -l {0}
-
       run: |
         pytest -v --cov=prj_2_2_2 --cov-report=xml --color=yes prj_2_2_2/tests/
 

--- a/.github/reference-workflows/CI_2_2_2.yaml
+++ b/.github/reference-workflows/CI_2_2_2.yaml
@@ -46,19 +46,19 @@ jobs:
       - name: Install package
         # conda setup requires this special shell
         shell: bash -l {0}
-      run: |
-        python -m pip install . --no-deps
-        micromamba list
+        run: |
+          python -m pip install . --no-deps
+          micromamba list
 
-    - name: Run tests
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        pytest -v --cov=prj_2_2_2 --cov-report=xml --color=yes prj_2_2_2/tests/
+      - name: Run tests
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          pytest -v --cov=prj_2_2_2 --cov-report=xml --color=yes prj_2_2_2/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_2_3_1.yaml
+++ b/.github/reference-workflows/CI_2_3_1.yaml
@@ -34,7 +34,6 @@ jobs:
         df -h
         ulimit -a
 
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -46,14 +45,11 @@ jobs:
         python -m pip install -U pytest pytest-cov codecov
 
     - name: Install package
-
       shell: bash
       run: |
         python -m pip install .
 
-
     - name: Run tests
-
       shell: bash
 
       run: |

--- a/.github/reference-workflows/CI_2_3_1.yaml
+++ b/.github/reference-workflows/CI_2_3_1.yaml
@@ -27,37 +27,37 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Testing Dependencies
-      shell: bash
-      run: |
-        python -m pip install -U pytest pytest-cov codecov
+      - name: Testing Dependencies
+        shell: bash
+        run: |
+          python -m pip install -U pytest pytest-cov codecov
 
-    - name: Install package
-      shell: bash
-      run: |
-        python -m pip install .
+      - name: Install package
+        shell: bash
+        run: |
+          python -m pip install .
 
-    - name: Run tests
-      shell: bash
+      - name: Run tests
+        shell: bash
 
-      run: |
-        pytest -v --cov=prj_2_3_1 --cov-report=xml --color=yes prj_2_3_1/tests/
+        run: |
+          pytest -v --cov=prj_2_3_1 --cov-report=xml --color=yes prj_2_3_1/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/reference-workflows/CI_2_3_2.yaml
+++ b/.github/reference-workflows/CI_2_3_2.yaml
@@ -34,7 +34,6 @@ jobs:
         df -h
         ulimit -a
 
-
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -46,14 +45,11 @@ jobs:
         python -m pip install -U pytest pytest-cov codecov
 
     - name: Install package
-
       shell: bash
       run: |
         python -m pip install .
 
-
     - name: Run tests
-
       shell: bash
 
       run: |

--- a/.github/reference-workflows/CI_2_3_2.yaml
+++ b/.github/reference-workflows/CI_2_3_2.yaml
@@ -27,37 +27,37 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Testing Dependencies
-      shell: bash
-      run: |
-        python -m pip install -U pytest pytest-cov codecov
+      - name: Testing Dependencies
+        shell: bash
+        run: |
+          python -m pip install -U pytest pytest-cov codecov
 
-    - name: Install package
-      shell: bash
-      run: |
-        python -m pip install .
+      - name: Install package
+        shell: bash
+        run: |
+          python -m pip install .
 
-    - name: Run tests
-      shell: bash
+      - name: Run tests
+        shell: bash
 
-      run: |
-        pytest -v --cov=prj_2_3_2 --cov-report=xml --color=yes prj_2_3_2/tests/
+        run: |
+          pytest -v --cov=prj_2_3_2 --cov-report=xml --color=yes prj_2_3_2/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}

--- a/.github/workflows/verify-ghas.yaml
+++ b/.github/workflows/verify-ghas.yaml
@@ -79,7 +79,7 @@ jobs:
         rtd: [1, 2]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: "Fetch Artifacts"
         uses: actions/download-artifact@v2
@@ -125,23 +125,19 @@ jobs:
           df -h
           ulimit -a
 
-#      - name: "Change directory"  # Have to CD here to make sure this works
-#        shell: bash
-#        run: |
+      #      - name: "Change directory"  # Have to CD here to make sure this works
+      #        shell: bash
+      #        run: |
       #          cd prj_${{ matrix.license }}_1_${{ matrix.rtd }}
 
-      # More info on options: https://github.com/conda-incubator/setup-miniconda
-      - uses: conda-incubator/setup-miniconda@v2
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
         with:
-          python-version: ${{ matrix.python-version }}
           environment-file: prj_${{ matrix.license }}_1_${{ matrix.rtd }}/devtools/conda-envs/test_env.yaml
-
+          environment-name: test
           channels: conda-forge,defaults
-
-          activate-environment: test
-          auto-update-conda: false
-          auto-activate-base: false
-          show-channel-urls: true
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
       - name: Install package
 
@@ -150,7 +146,7 @@ jobs:
         working-directory: prj_${{ matrix.license }}_1_${{ matrix.rtd }}  # Nonstandard
         run: |
           python -m pip install . --no-deps
-          conda list
+          micromamba list
 
 
       - name: Run tests
@@ -195,21 +191,19 @@ jobs:
         with:
           name: cookiecutter_outputs
 
-#      - name: "Change directory"  # Have to CD here to make sure this works
-#        shell: bash
-#        run: |
+      #      - name: "Change directory"  # Have to CD here to make sure this works
+      #        shell: bash
+      #        run: |
       #          cd prj_${{ matrix.license }}_2_${{ matrix.rtd }}
 
-      # More info on options: https://github.com/conda-incubator/setup-miniconda
-      - uses: conda-incubator/setup-miniconda@v2
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
         with:
-          python-version: ${{ matrix.python-version }}
           environment-file: prj_${{ matrix.license }}_2_${{ matrix.rtd }}/devtools/conda-envs/test_env.yaml
-
-          activate-environment: test
-          auto-update-conda: false
-          auto-activate-base: false
-          show-channel-urls: true
+          environment-name: test
+          channels: defaults
+          extra-specs: |
+            python=${{ matrix.python-version }}
 
       - name: Install package
 
@@ -218,7 +212,7 @@ jobs:
         working-directory: prj_${{ matrix.license }}_2_${{ matrix.rtd }}  # Nonstandard
         run: |
           python -m pip install . --no-deps
-          conda list
+          micromamba list
 
 
       - name: Run tests

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A [cookiecutter](https://github.com/cookiecutter/cookiecutter) template for those interested in developing computational
 molecular packages in Python. Skeletal starting repositories can be created from this template to create the file
-structure semi-autonomously so you can focus on what's important: the science!
+structure semi-autonomously, so you can focus on what's important: the science!
 
 The skeletal structure is designed to help you get started, but do not feel limited by the skeleton's features included
 here. Just to name a few things you can alter to suit your needs: change continuous integration options, remove
@@ -105,12 +105,12 @@ Tests can be run with the `pytest -v` command. There are a number of additional 
 
 ### Continuous Integration (GitHub Actions)
 
-As of version 1.3, we provide preconfigured workflows for [GitHub Actions](https://github.com/features/actions), with 
-support for Linux, MacOS and Windows. Conda support is possible thanks to the excellent 
-[@conda-incubator's `setup-miniconda` action](https://github.com/conda-incubator/setup-miniconda). We encourage you 
-read its documentation for further details on GitHub Actions themselves.
+As of version 1.3, we provide preconfigured workflows for [GitHub Actions](https://github.com/features/actions), with
+support for Linux, MacOS and Windows. Conda support is possible thanks to the excellent
+[@mamba-org's `provision-with-micromamba` action](https://github.com/marketplace/actions/provision-with-micromamba). We
+encourage you read its documentation for further details on GitHub Actions themselves.
 
-The Cookiecutter's GitHub Actions does a number of things differently than the output Actions. We detail those 
+The Cookiecutter's GitHub Actions does a number of things differently than the output Actions. We detail those
 differences below, but none of this is needed to understand the output GitHub Action Workflows, which are much simpler.
 
 The Cookiecutter ability to test GitHub Actions it generates has some limitations, but are still properly tested.
@@ -169,9 +169,9 @@ links below. We do not implement them for this Cookiecutter, but they can be add
 
 * [GitHub Actions Caching](https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows)
 
-There are caching capabilities for the `Conda-Incubator/setup-miniconda` action, if you are using it as well. 
+There are caching capabilities for the `mamba-org/provision-with-micromamba` action, if you are using it as well.
 
-* [Setup Miniconda GHA Caching](https://github.com/conda-incubator/setup-miniconda#caching)
+* [Setup Micromamba GHA Caching](https://github.com/mamba-org/provision-with-micromamba#cache-downloads)
 
 ### Documentation
 Make a [ReadTheDocs](https://readthedocs.org) account and turn on the git hook. Although you can manually make the

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,5 +19,5 @@
     ],
     
     "include_ReadTheDocs": ["y", "n"],
-  "_cms_cc_version": 1.9
+  "_cms_cc_version": 1.10
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,9 @@ Features
 .. versionchanged:: 1.9
     Added support for :pep:`621`. Update to Python 3.10
 
+.. versionchanged:: 1.10
+    Switched to Micromamba as CI conda source.
+
 Requirements
 ------------
 

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -27,13 +27,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-    - name: Additional info about the build
-      shell: bash
-      run: |
-        uname -a
-        df -h
-        ulimit -a
-{% if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
+      - name: Additional info about the build
+        shell: bash
+        run: |
+          uname -a
+          df -h
+          ulimit -a
+  { % if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' % }
 - name: Set up Python {{ '${{ matrix.python-version }}' }}
   uses: actions/setup-python@v2
   with:
@@ -62,14 +62,13 @@ extra-specs: |
 shell: bash
 run: |
   python -m pip install .
-  { %- else % }
+  { % else % }
 # conda setup requires this special shell
 shell: bash -l {0}
 run: |
   python -m pip install . --no-deps
   micromamba list
-  { %- endif % }
-
+  { % endif % }
 - name: Run tests
   { %- if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' % }
 shell: bash
@@ -80,9 +79,9 @@ shell: bash -l {0}
 run: |
   pytest -v --cov={{ cookiecutter.repo_name }} --cov-report=xml --color=yes {{ cookiecutter.repo_name }}/tests/
 
-    - name: CodeCov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        flags: unittests
-        name: codecov-{{ '${{ matrix.os }}' }}-py{{ '${{ matrix.python-version }}' }}
+- name: CodeCov
+  uses: codecov/codecov-action@v1
+  with:
+    file: ./coverage.xml
+    flags: unittests
+    name: codecov-{{ '${{ matrix.os }}' }}-py{{ '${{ matrix.python-version }}' }}

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -33,55 +33,55 @@ jobs:
           uname -a
           df -h
           ulimit -a
-  { % if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' % }
-- name: Set up Python {{ '${{ matrix.python-version }}' }}
-  uses: actions/setup-python@v2
-  with:
-    python-version: { { '${{ matrix.python-version }}' } }
+{% if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
+      - name: Set up Python {{ '${{ matrix.python-version }}' }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: {{ '${{ matrix.python-version }}' }}
 
-- name: Testing Dependencies
-  shell: bash
-  run: |
-    python -m pip install -U pytest pytest-cov codecov
-  { % else % }
-# More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-- uses: mamba-org/provision-with-micromamba@main
-  with:
-    environment-file: devtools/conda-envs/test_env.yaml
-    environment-name: test
-  { %- if cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' % }
-channels: conda-forge,defaults
-  { %- elif cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback' % }
-channels: defaults
-  { %- endif % }
-extra-specs: |
-  python={{ '${{ matrix.python-version }}' }}
-  { % endif % }
-- name: Install package
-  { %- if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' % }
-shell: bash
-run: |
-  python -m pip install .
-  { % else % }
-# conda setup requires this special shell
-shell: bash -l {0}
-run: |
-  python -m pip install . --no-deps
-  micromamba list
-  { % endif % }
-- name: Run tests
-  { %- if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' % }
-shell: bash
-  { % else % }
-# conda setup requires this special shell
-shell: bash -l {0}
-  { %- endif % }
-run: |
-  pytest -v --cov={{ cookiecutter.repo_name }} --cov-report=xml --color=yes {{ cookiecutter.repo_name }}/tests/
+      - name: Testing Dependencies
+        shell: bash
+        run: |
+          python -m pip install -U pytest pytest-cov codecov
+{% else %}
+      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+      - uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: devtools/conda-envs/test_env.yaml
+          environment-name: test
+{%- if cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' %}
+          channels: conda-forge,defaults
+{%- elif cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback' %}
+          channels: defaults
+{%- endif %}
+          extra-specs: |
+            python={{ '${{ matrix.python-version }}' }}
+{% endif %}
+      - name: Install package
+{%- if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
+        shell: bash
+        run: |
+          python -m pip install .
+{% else %}
+        # conda setup requires this special shell
+        shell: bash -l {0}
+        run: |
+          python -m pip install . --no-deps
+          micromamba list
+{% endif %}
+      - name: Run tests
+{%- if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
+        shell: bash
+{% else %}
+        # conda setup requires this special shell
+        shell: bash -l {0}
+{%- endif %}
+        run: |
+          pytest -v --cov={{ cookiecutter.repo_name }} --cov-report=xml --color=yes {{ cookiecutter.repo_name }}/tests/
 
-- name: CodeCov
-  uses: codecov/codecov-action@v1
-  with:
-    file: ./coverage.xml
-    flags: unittests
-    name: codecov-{{ '${{ matrix.os }}' }}-py{{ '${{ matrix.python-version }}' }}
+      - name: CodeCov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-{{ '${{ matrix.os }}' }}-py{{ '${{ matrix.python-version }}' }}

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -33,55 +33,52 @@ jobs:
         uname -a
         df -h
         ulimit -a
-
 {% if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
-    - name: Set up Python {{ '${{ matrix.python-version }}' }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: {{ '${{ matrix.python-version }}' }}
+- name: Set up Python {{ '${{ matrix.python-version }}' }}
+  uses: actions/setup-python@v2
+  with:
+    python-version: { { '${{ matrix.python-version }}' } }
 
-    - name: Testing Dependencies
-      shell: bash
-      run: |
-        python -m pip install -U pytest pytest-cov codecov
-{% else %}
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: {{ '${{ matrix.python-version }}' }}
-        environment-file: devtools/conda-envs/test_env.yaml
-{% if cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' %}
-        channels: conda-forge,defaults
-{% elif cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback' %}
-        channels: defaults
-{% endif %}
-        activate-environment: test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
-{% endif %}
-    - name: Install package
-{% if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
-      shell: bash
-      run: |
-        python -m pip install .
-{% else %}
-      # conda setup requires this special shell
-      shell: bash -l {0}
-      run: |
-        python -m pip install . --no-deps
-        conda list
-{% endif %}
+- name: Testing Dependencies
+  shell: bash
+  run: |
+    python -m pip install -U pytest pytest-cov codecov
+  { % else % }
+# More info on options: https://github.com/marketplace/actions/provision-with-micromamba
+- uses: mamba-org/provision-with-micromamba@main
+  with:
+    environment-file: devtools/conda-envs/test_env.yaml
+    environment-name: test
+  { %- if cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' % }
+channels: conda-forge,defaults
+  { %- elif cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback' % }
+channels: defaults
+  { %- endif % }
+extra-specs: |
+  python={{ '${{ matrix.python-version }}' }}
+  { % endif % }
+- name: Install package
+  { %- if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' % }
+shell: bash
+run: |
+  python -m pip install .
+  { %- else % }
+# conda setup requires this special shell
+shell: bash -l {0}
+run: |
+  python -m pip install . --no-deps
+  micromamba list
+  { %- endif % }
 
-    - name: Run tests
-{% if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' %}
-      shell: bash
-{% else %}
-      # conda setup requires this special shell
-      shell: bash -l {0}
-{% endif %}
-      run: |
-        pytest -v --cov={{ cookiecutter.repo_name }} --cov-report=xml --color=yes {{ cookiecutter.repo_name }}/tests/
+- name: Run tests
+  { %- if cookiecutter.dependency_source == 'Dependencies from pip only (no conda)' % }
+shell: bash
+  { % else % }
+# conda setup requires this special shell
+shell: bash -l {0}
+  { %- endif % }
+run: |
+  pytest -v --cov={{ cookiecutter.repo_name }} --cov-report=xml --color=yes {{ cookiecutter.repo_name }}/tests/
 
     - name: CodeCov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
Fixes #139

Switches over to `mamba-org/provision-with-micromamba` instead of `conda-incubator/setup-miniconda` for speed.

Fixed a bug in the CI file where extra spaces were added to the checkout line, which would fail the YAML parsing.

cc @jaimergp @mikemhenry @janash 