### PR TITLE
Remove use of `pytest-runner` as recommended

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -34,7 +34,6 @@ requires-python = ">=3.8"
 [project.optional-dependencies]
 test = [
   "pytest>=6.1.2",
-  "pytest-runner"
 ]
 
 [tool.setuptools]

--- a/{{cookiecutter.repo_name}}/setup.cfg
+++ b/{{cookiecutter.repo_name}}/setup.cfg
@@ -41,9 +41,6 @@ classifiers ={% if cookiecutter.open_source_license == 'MIT' %}
 zip_safe = False
 install_requires =
     importlib-resources; python_version<"3.10"
-tests_require =
-    pytest>=6.1.2
-    pytest-runner
 # Which Python importable modules should be included when your package is installed
 # Handled automatically by setuptools. Use 'exclude' to prevent some specific
 # subpackage(s) from being added, if needed


### PR DESCRIPTION
`pytest-runner` is (intentionally) no longer maintained as its key feature (`python setup.py test` or something like that) now relies on tooling that's been deprecated for ages but is only now being phased out. Considering `setup.py` has been removed from this project altogether, it's probably not useful to install a tool that requires it.

https://github.com/pytest-dev/pytest-runner/blob/1898992b5497afaf17e65d1d460688c0e5177b81/README.rst#deprecation-notice

I couldn't find any chatter in this repo about it; personally I've never used this feature so I may be missing context.