### PR TITLE
replace yaml.load calls with yaml.safe_load

### DIFF
--- a/tests/run_yaml.py
+++ b/tests/run_yaml.py
@@ -13,7 +13,7 @@ def parse_yaml(filename, key):
     """
 
     with open(filename, "r") as infile:
-        ret = yaml.load(infile) 
+        ret = yaml.safe_load(infile)
 
     return ret[key]
 

--- a/{{cookiecutter.repo_name}}/devtools/scripts/create_conda_env.py
+++ b/{{cookiecutter.repo_name}}/devtools/scripts/create_conda_env.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 # YAML imports
 try:
     import yaml  # PyYAML
-    loader = yaml.load
+    loader = yaml.safe_load
 except ImportError:
     try:
         import ruamel_yaml as yaml  # Ruamel YAML


### PR DESCRIPTION
Since the use `yaml.load` function without a Loader argument is deprecated since pyyaml 5.1 replace `yaml.loader` calls with `yaml.safe_loader`. `yaml.safe_loader` is a shorthand for calling `yaml.load` with the `SafeLoader` class as `Loader` argument.

This PR resolves #167 