### PR TITLE
Replacing provision-with-micromamba action with setup-micromamba action.

### DIFF
--- a/.github/reference-workflows/CI_1_1_1.yaml
+++ b/.github/reference-workflows/CI_1_1_1.yaml
@@ -34,13 +34,16 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: conda-forge,defaults
-          extra-specs: |
+          condarc: |
+            channels:
+              - conda-forge
+              - defaults
+          create-args: >- 
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/reference-workflows/CI_1_1_2.yaml
+++ b/.github/reference-workflows/CI_1_1_2.yaml
@@ -34,13 +34,16 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: conda-forge,defaults
-          extra-specs: |
+          condarc: |
+            channels:
+              - conda-forge
+              - defaults
+          create-args: >- 
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/reference-workflows/CI_1_2_1.yaml
+++ b/.github/reference-workflows/CI_1_2_1.yaml
@@ -34,13 +34,15 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: defaults
-          extra-specs: |
+          condarc: |
+            channels:
+              - defaults
+          create-args: >- 
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/reference-workflows/CI_1_2_2.yaml
+++ b/.github/reference-workflows/CI_1_2_2.yaml
@@ -34,13 +34,15 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: defaults
-          extra-specs: |
+          condarc: |
+            channels:
+              - defaults
+          create-args: >- 
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/reference-workflows/CI_2_1_1.yaml
+++ b/.github/reference-workflows/CI_2_1_1.yaml
@@ -34,13 +34,16 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: conda-forge,defaults
-          extra-specs: |
+          condarc: |
+            channels:
+              - conda-forge
+              - defaults
+          create-args: >- 
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/reference-workflows/CI_2_1_2.yaml
+++ b/.github/reference-workflows/CI_2_1_2.yaml
@@ -34,13 +34,16 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: conda-forge,defaults
-          extra-specs: |
+          condarc: |
+            channels:
+              - conda-forge
+              - defaults
+          create-args: >- 
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/reference-workflows/CI_2_2_1.yaml
+++ b/.github/reference-workflows/CI_2_2_1.yaml
@@ -34,13 +34,15 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: defaults
-          extra-specs: |
+          condarc: |
+            channels:
+              - defaults
+          create-args: >- 
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/reference-workflows/CI_2_2_2.yaml
+++ b/.github/reference-workflows/CI_2_2_2.yaml
@@ -34,13 +34,15 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: defaults
-          extra-specs: |
+          condarc: |
+            channels:
+              - defaults
+          create-args: >- 
             python=${{ matrix.python-version }}
 
       - name: Install package

--- a/.github/workflows/verify-ghas.yaml
+++ b/.github/workflows/verify-ghas.yaml
@@ -130,14 +130,17 @@ jobs:
       #        run: |
       #          cd prj_${{ matrix.license }}_1_${{ matrix.rtd }}
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: prj_${{ matrix.license }}_1_${{ matrix.rtd }}/devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: conda-forge,defaults
-          extra-specs: |
+          create-args: >- 
             python=${{ matrix.python-version }}
+          condarc: |
+            channels:
+              - conda-forge
+              - defaults
 
       - name: Install package
 
@@ -196,14 +199,16 @@ jobs:
       #        run: |
       #          cd prj_${{ matrix.license }}_2_${{ matrix.rtd }}
 
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: prj_${{ matrix.license }}_2_${{ matrix.rtd }}/devtools/conda-envs/test_env.yaml
           environment-name: test
-          channels: defaults
-          extra-specs: |
+          create-args: >- 
             python=${{ matrix.python-version }}
+          condarc: |
+            channels:
+              - defaults
 
       - name: Install package
 

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -44,17 +44,22 @@ jobs:
         run: |
           python -m pip install -U pytest pytest-cov codecov
 {% else %}
-      # More info on options: https://github.com/marketplace/actions/provision-with-micromamba
-      - uses: mamba-org/provision-with-micromamba@main
+      # More info on options: https://github.com/marketplace/actions/setup-micromamba
+      - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
 {%- if cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' %}
-          channels: conda-forge,defaults
+          condarc: |
+            channels:
+              - conda-forge
+              - defaults
 {%- elif cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback' %}
-          channels: defaults
+          condarc: |
+            channels:
+              - defaults
 {%- endif %}
-          extra-specs: |
+          create-args: >- 
             python={{ '${{ matrix.python-version }}' }}
 {% endif %}
       - name: Install package


### PR DESCRIPTION
This PR is replacing the deprecated [provision-with-micromamba](https://github.com/marketplace/actions/provision-with-micromamba) action with the newer [setup-micromamba](https://github.com/marketplace/actions/setup-micromamba) action.

Updates follow the recommended migration steps from the provision-with-micromamba page.

Actions to update:
- [x] verify-ghas.yaml - conda-forge-dep
- [x] verify-ghas.yaml - conda-defaults-dep
- [x] cookiecutter ci.yaml - test