### PR TITLE
Improves cookiecutter post generation scripts

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -17,16 +17,20 @@ def decode_string(string):
         return string
 
 
-def invoke_shell(command, expected_error=True, print_output=True):
+def invoke_shell(command, error_ok=False, print_output=True):
+    
+    return_code = 0 # Successful return code
+
     try:
         output = sp.check_output(command, shell=True, stderr=sp.STDOUT)
     except sp.CalledProcessError as e:
         output = e.output
-        if not expected_error:
+        return_code = e.returncode
+        if not error_ok:
             raise e
     if print_output:
         print(decode_string(output))
-    return decode_string(output)
+    return decode_string(output), return_code
 
 
 def git_init_and_tag():
@@ -35,12 +39,17 @@ def git_init_and_tag():
     Versioneer to ID if not already in a git repository.
     """
     
-    # Check if we are in a git repository
-    directory_status = invoke_shell("git status", expected_error=True, print_output=False)
+    # Check if we are in a git repository - calling `git status` outside of a git repository will return 128
+    _, return_code = invoke_shell("git status", error_ok=True, print_output=False)
     # Create a repository and commit if not in one.
-    if 'fatal' in directory_status:
+    if return_code == 128:
         # Initialize git
-        invoke_shell("git init --initial-branch=main")
+        invoke_shell("git init")
+
+        # change default branch name to main
+        # safer than --init-branch=main
+        # because it works with older versions of git
+        invoke_shell("git branch -M main")
 
         # Add files created by cookiecutter 
         invoke_shell("git add .")
@@ -49,7 +58,7 @@ def git_init_and_tag():
                 '{{ cookiecutter._cms_cc_version }}'))
         
         # Check for a tag
-        version = invoke_shell("git tag", expected_error=True)
+        version = invoke_shell("git tag", error_ok=True)
         # Tag if no tag exists
         if not version:
             invoke_shell("git tag 0.0.0")

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -18,13 +18,9 @@ def decode_string(string):
 
 
 def invoke_shell(command, expected_error=True, print_output=True):
-
     try:
         output = sp.check_output(command, shell=True, stderr=sp.STDOUT)
     except sp.CalledProcessError as e:
-        # Trap and print the output in a helpful way
-        print(decode_string(e.output), decode_string(e.returncode))
-        print(e.output)
         output = e.output
         if not expected_error:
             raise e


### PR DESCRIPTION
This PR makes a few improvements to the post-generation cookiecutter scripts, particularly the `git_init_and_tag` function.

* `invoke_shell` is fixed so that output (including error from `git status`), resulting in the somewhat confusing `git` error message to no longer print.
* `expected_error` argument to `invoke_shell` is changed to `error_ok` - this seems more clear.
* return code is added to `invoke_shell`
* return code (instead of output message) is checked for `git init`.
* `--init-branch=main` is replaced with `git branch -M  main` after first commit. This will enable cookiecutter to work with older git versions. `--init-branch=main` is only an option for git > 2.28, but `git branch -M main` after the first commit will work for versions before 2.28.