### PR TITLE
remove pytest-runner

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -34,7 +34,6 @@ requires-python = ">=3.8"
 [project.optional-dependencies]
 test = [
   "pytest>=6.1.2",
-  "pytest-runner"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
This PR removes `pytest-runner` from testing dependencies in `pyproject.toml`.