### PR TITLE
Updating Checkout action and python versions.

### DIFF
--- a/.github/reference-workflows/CI_1_1_1.yaml
+++ b/.github/reference-workflows/CI_1_1_1.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_1_1_2.yaml
+++ b/.github/reference-workflows/CI_1_1_2.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_1_2_1.yaml
+++ b/.github/reference-workflows/CI_1_2_1.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_1_2_2.yaml
+++ b/.github/reference-workflows/CI_1_2_2.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_1_3_1.yaml
+++ b/.github/reference-workflows/CI_1_3_1.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_1_3_2.yaml
+++ b/.github/reference-workflows/CI_1_3_2.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_2_1_1.yaml
+++ b/.github/reference-workflows/CI_2_1_1.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_2_1_2.yaml
+++ b/.github/reference-workflows/CI_2_1_2.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_2_2_1.yaml
+++ b/.github/reference-workflows/CI_2_2_1.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_2_2_2.yaml
+++ b/.github/reference-workflows/CI_2_2_2.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_2_3_1.yaml
+++ b/.github/reference-workflows/CI_2_3_1.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/reference-workflows/CI_2_3_2.yaml
+++ b/.github/reference-workflows/CI_2_3_2.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash

--- a/.github/workflows/verify-ghas.yaml
+++ b/.github/workflows/verify-ghas.yaml
@@ -31,9 +31,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [ 3.8, 3.9, "3.10" ]
+        python-version: [3.9, "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -80,7 +80,7 @@ jobs:
         rtd: [1, 2]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Fetch Artifacts"
         uses: actions/download-artifact@v2
@@ -108,11 +108,11 @@ jobs:
     strategy:  # Approximate strategy, uses a few other options
       matrix:
         os: [ubuntu-latest , macOS-latest, windows-latest]
-        python-version: [ 3.8, 3.9, "3.10" ]
+        python-version: [3.9, "3.10", "3.11"]
         license: [1]  # Nonstandard
         rtd: [1, 2]  # Nonstandard
     steps:
-      # - uses: actions/checkout@v3  # This isn't necessary here
+      # - uses: actions/checkout@v4  # This isn't necessary here
 
       - name: "Fetch Artifacts"
         uses: actions/download-artifact@v2
@@ -176,12 +176,12 @@ jobs:
     strategy:  # Approximate strategy, uses a few other options
       matrix:
         os: [ubuntu-latest , macOS-latest, windows-latest]
-        python-version: [ 3.8, 3.9, "3.10" ]
+        python-version: [3.9, "3.10", "3.11"]
         license: [1]  # Nonstandard
         rtd: [1, 2]  # Nonstandard
 
     steps:
-      # - uses: actions/checkout@v3  # This isn't necessary here
+      # - uses: actions/checkout@v4  # This isn't necessary here
 
       - name: Additional info about the build
         shell: bash
@@ -243,12 +243,12 @@ jobs:
     strategy:  # Approximate strategy, uses a few other options
       matrix:
         os: [ubuntu-latest , macOS-latest, windows-latest]
-        python-version: [ 3.8, 3.9, "3.10" ]
+        python-version: [3.9, "3.10", "3.11"]
         license: [1]  # Nonstandard
         rtd: [1, 2]  # Nonstandard
 
     steps:
-      # - uses: actions/checkout@v3  # This isn't necessary here
+      # - uses: actions/checkout@v4  # This isn't necessary here
 
       - name: Additional info about the build
         shell: bash

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -22,10 +22,10 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.9, "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Additional info about the build
         shell: bash


### PR DESCRIPTION
This PR updates the checkout github action to use the current v4 instead of v3. It also updates the python versions that the CI is testing against to be 3.9, 3.10, and 3.11.