### PR TITLE
Conda forge only

### DIFF
--- a/.github/reference-workflows/CI_1_1_1.yaml
+++ b/.github/reference-workflows/CI_1_1_1.yaml
@@ -42,7 +42,6 @@ jobs:
           condarc: |
             channels:
               - conda-forge
-              - defaults
           create-args: >- 
             python=${{ matrix.python-version }}
 

--- a/.github/reference-workflows/CI_1_1_2.yaml
+++ b/.github/reference-workflows/CI_1_1_2.yaml
@@ -42,7 +42,6 @@ jobs:
           condarc: |
             channels:
               - conda-forge
-              - defaults
           create-args: >- 
             python=${{ matrix.python-version }}
 

--- a/.github/reference-workflows/CI_2_1_1.yaml
+++ b/.github/reference-workflows/CI_2_1_1.yaml
@@ -42,7 +42,6 @@ jobs:
           condarc: |
             channels:
               - conda-forge
-              - defaults
           create-args: >- 
             python=${{ matrix.python-version }}
 

--- a/.github/reference-workflows/CI_2_1_2.yaml
+++ b/.github/reference-workflows/CI_2_1_2.yaml
@@ -42,7 +42,6 @@ jobs:
           condarc: |
             channels:
               - conda-forge
-              - defaults
           create-args: >- 
             python=${{ matrix.python-version }}
 

--- a/.github/workflows/verify-ghas.yaml
+++ b/.github/workflows/verify-ghas.yaml
@@ -141,7 +141,6 @@ jobs:
           condarc: |
             channels:
               - conda-forge
-              - defaults
 
       - name: Install package
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,7 +13,7 @@
         "Not Open Source"
     ],
     "dependency_source": [
-        "Prefer conda-forge over the default anaconda channel with pip fallback",
+        "Prefer conda-forge with pip fallback",
         "Prefer default anaconda channel with pip fallback",
         "Dependencies from pip only (no conda)"
     ],

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -49,11 +49,10 @@ jobs:
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test
-{%- if cookiecutter.dependency_source == 'Prefer conda-forge over the default anaconda channel with pip fallback' %}
+{%- if cookiecutter.dependency_source == 'Prefer conda-forge with pip fallback' %}
           condarc: |
             channels:
               - conda-forge
-              - defaults
 {%- elif cookiecutter.dependency_source == 'Prefer default anaconda channel with pip fallback' %}
           condarc: |
             channels:


### PR DESCRIPTION
This PR removes the default channel from the conda-forge option of the cookiecutter.
This should close #160. 