### PR TITLE
fix: updated to add a tag message for the initial git tag

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -56,7 +56,7 @@ def git_init_and_tag():
         version = invoke_shell("git tag", expected_error=True)
         # Tag if no tag exists
         if not version:
-            invoke_shell("git tag 0.0.0")
+            invoke_shell("git tag 0.0.0 -m \"Initial commit from MolSSI cookie cutter\"")
     else:
         print("\ngit repository detected. "
               "CookieCutter files have been created in {{ cookiecutter.repo_name }} directory.")


### PR DESCRIPTION
This PR fixes a bug wherein a message must be added if a user sets up git to GPG sign tags, doing so requires that every tag have a message. Without this, the installation will hang.