### PR TITLE
Switch `_cms_cc_version` to string, not number

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,5 +19,5 @@
     ],
     
     "include_ReadTheDocs": ["y", "n"],
-  "_cms_cc_version": 1.10
+  "_cms_cc_version": "1.10"
 }


### PR DESCRIPTION
Versions should be strings. Version 1.10 was being recorded as version 1.1.