### PR TITLE
Minor version 10 being miscast as .1

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,5 +19,5 @@
     ],
     
     "include_ReadTheDocs": ["y", "n"],
-  "_cms_cc_version": 1.10
+  "_cms_cc_version": "1.10"
 }


### PR DESCRIPTION
This turns the CC version into a string so that X.10 does not get converted to X.1 in print. This would happen with X.20 but not X.11 or X.25 for example.