### PR TITLE
chore: update CI Python versions to use SPEC0

### DIFF
--- a/.github/reference-workflows/CI_1_1_1.yaml
+++ b/.github/reference-workflows/CI_1_1_1.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_1_1_2.yaml
+++ b/.github/reference-workflows/CI_1_1_2.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_1_2_1.yaml
+++ b/.github/reference-workflows/CI_1_2_1.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_1_2_2.yaml
+++ b/.github/reference-workflows/CI_1_2_2.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_1_3_1.yaml
+++ b/.github/reference-workflows/CI_1_3_1.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_1_3_2.yaml
+++ b/.github/reference-workflows/CI_1_3_2.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_2_1_1.yaml
+++ b/.github/reference-workflows/CI_2_1_1.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_2_1_2.yaml
+++ b/.github/reference-workflows/CI_2_1_2.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_2_2_1.yaml
+++ b/.github/reference-workflows/CI_2_2_1.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_2_2_2.yaml
+++ b/.github/reference-workflows/CI_2_2_2.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_2_3_1.yaml
+++ b/.github/reference-workflows/CI_2_3_1.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/reference-workflows/CI_2_3_2.yaml
+++ b/.github/reference-workflows/CI_2_3_2.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/verify-ghas.yaml
+++ b/.github/workflows/verify-ghas.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -108,7 +108,7 @@ jobs:
     strategy:  # Approximate strategy, uses a few other options
       matrix:
         os: [ubuntu-latest , macOS-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
         license: [1]  # Nonstandard
         rtd: [1, 2]  # Nonstandard
     steps:
@@ -175,7 +175,7 @@ jobs:
     strategy:  # Approximate strategy, uses a few other options
       matrix:
         os: [ubuntu-latest , macOS-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
         license: [1]  # Nonstandard
         rtd: [1, 2]  # Nonstandard
 
@@ -242,7 +242,7 @@ jobs:
     strategy:  # Approximate strategy, uses a few other options
       matrix:
         os: [ubuntu-latest , macOS-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
         license: [1]  # Nonstandard
         rtd: [1, 2]  # Nonstandard
 

--- a/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/CI.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.9, "3.10", "3.11"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR aims to make the cookiecutter compliant with the most recent version of SPEC0 from Scientific Python. This is the standard for scientific packages and ensures that we keep new projects up-to-date with current standards.

For more information on SPEC0 see here: https://scientific-python.org/specs/spec-0000/

For those looking to update in the future, you can use a script like the following:
```bash
rg 'python-version: \[.*' --hidden --files-with-matches | xargs sed -i '' -E 's/python-version: \[.*/python-version: \["3.11", "3.12", "3.13"\]/g'
```