### PR TITLE
Update license metadata

### DIFF
--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -12,12 +12,9 @@ readme = "README.md"
 authors = [
     { name = "{{cookiecutter.author_name}}", email = "{{cookiecutter.author_email}}" }
 ]
-license = { text = "{{cookiecutter.open_source_license}}" }
+license = "{{cookiecutter.open_source_license}}"
 # See https://pypi.org/classifiers/
-classifiers = [{% if cookiecutter.open_source_license == 'MIT' %}
-    "License :: OSI Approved :: MIT License",{% elif cookiecutter.open_source_license == 'BSD-3-Clause' %}
-    "License :: OSI Approved :: BSD License",{% elif cookiecutter.open_source_license == 'LGPLv3' %}
-    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",{% endif %}
+classifiers = [
     "Programming Language :: Python :: 3",
 ]
 requires-python = ">=3.8"

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -13,6 +13,7 @@ authors = [
     { name = "{{cookiecutter.author_name}}", email = "{{cookiecutter.author_email}}" }
 ]
 license = "{{cookiecutter.open_source_license}}"
+license-files = ["LICENSE"]
 # See https://pypi.org/classifiers/
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## USE PEP 639-compliant license metadata

This PR updates the project’s `pyproject.toml` to adopt [[PEP 639](https://peps.python.org/pep-0639/)](https://peps.python.org/pep-0639/) license specification, as recommended by [[Python Packaging Authority](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)]. 

### Changes:

* Changed deprecated `license = {file = "LICENSE"}` table syntax to `license = "MIT"` as a valid SPDX expression (string).
* Added `license-files = ["LICENSE"]` to explicitly include the license file.
* Removed outdated `License :: OSI Approved :: MIT License` classifier, which is now discouraged in favor of SPDX.

