### PR TITLE
Add github username field to the questions for the README badges

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,6 +4,7 @@
     "first_module_name": "{{ cookiecutter.repo_name.lower().replace(' ', '_') }}",
     "author_name": "Your name (or your organization/company/team)",
     "author_email": "Your email (or your organization/company/team)",
+    "owner_account": "Your github user name (or the organization/company/team)",
     "description": "A short description of the project (less than one line).",
     "open_source_license": [
 

--- a/tests/setup_cookiecutter.py
+++ b/tests/setup_cookiecutter.py
@@ -23,6 +23,7 @@ options = [project,  # Repo name
            project,  # First module name
            "cookie monster",  # Author name
            "cookiemonster@trash.can",  # Author email
+           "cookie_monster", #Author github username
            "",  # Description
            lic,  # License
            provider,  # ci_provider

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -1,8 +1,8 @@
 {{cookiecutter.project_name}}
 ==============================
 [//]: # (Badges)
-[![GitHub Actions Build Status](https://github.com/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.repo_name}}/workflows/CI/badge.svg)](https://github.com/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.repo_name}}/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}}/branch/main/graph/badge.svg)](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/{{cookiecutter.project_name}}/branch/main)
+[![GitHub Actions Build Status](https://github.com/{{cookiecutter.owner_account}}/{{cookiecutter.repo_name}}/workflows/CI/badge.svg)](https://github.com/{{cookiecutter.owner_account}}/{{cookiecutter.repo_name}}/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/{{cookiecutter.owner_account}}/{{cookiecutter.project_name}}/branch/main/graph/badge.svg)](https://codecov.io/gh/{{cookiecutter.owner_account}}/{{cookiecutter.project_name}}/branch/main)
 
 
 {{cookiecutter.description}}

--- a/{{cookiecutter.repo_name}}/pyproject.toml
+++ b/{{cookiecutter.repo_name}}/pyproject.toml
@@ -26,7 +26,7 @@ requires-python = ">=3.8"
 
 # Update the urls once the hosting is set up.
 #[project.urls]
-#"Source" = "https://github.com/<username>/{{cookiecutter.repo_name}}/"
+#"Source" = "https://github.com/{{cookiecutter.owner_account}}/{{cookiecutter.repo_name}}/"
 #"Documentation" = "https://{{cookiecutter.repo_name}}.readthedocs.io/"
 
 [project.optional-dependencies]


### PR DESCRIPTION
This patch adds an owner_account field to the cookiecutter.json file, which is then used to automatically populate the GitHub badge URLs in the generated README.md. This is to help ensure that badges (CI status and code coverage) work correctly from the start, avoiding having to replace the default placeholder (REPLACE_WITH_OWNER_ACCOUNT) during setup, which can be easy to miss. 