### PR TITLE
Add explicit Sphinx configuration path to .readthedocs.yaml

### DIFF
--- a/{{cookiecutter.repo_name}}/.readthedocs.yaml
+++ b/{{cookiecutter.repo_name}}/.readthedocs.yaml
@@ -5,5 +5,8 @@ build:
   tools:
     python: "mambaforge-22.9"
 
+sphinx:
+   configuration: docs/conf.py
+
 conda:
   environment: docs/requirements.yaml


### PR DESCRIPTION
ReadTheDocs deprecated automatic detection of Sphinx configuration files. This commit adds an explicit sphinx.configuration: docs/conf.py entry to .readthedocs.yaml to ensure compatibility with their policy change (effective Jan 20, 2025).

Reference: https://blog.readthedocs.com/posts/2024-06-17-deprecate-implicit-config/